### PR TITLE
fix: added use of user preferredlanguage as locales for picker

### DIFF
--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -102,6 +102,15 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
       },
     ],
     'expo-sqlite',
+    [
+      'expo-localization',
+      {
+        supportedLocales: {
+          ios: ['en', 'ja'],
+          android: ['en', 'ja'],
+        },
+      },
+    ],
   ],
   extra: {
     router: {},

--- a/mobile/components/BottomSheets/EditExpenseBottomSheet.tsx
+++ b/mobile/components/BottomSheets/EditExpenseBottomSheet.tsx
@@ -16,6 +16,7 @@ import { getExpenseFullById } from '../../db/repository/expense';
 import { getPaymentMethodsByUserId } from '../../db/repository/paymentMethod';
 import type { Category, Expense, PaymentMethod } from '../../db/schema';
 import { validateCurrencyInput } from '../../db/utils';
+import { formatDateWithLocale } from '../../utils/datetime';
 import { useRefreshKey } from '../contexts/RefreshKeyContext';
 import { useUser } from '../contexts/UserContext';
 import { BSTextInput } from './BottomSheetTextInput';
@@ -197,15 +198,6 @@ export default function EditExpenseBottomSheet({
     setShowDatePicker(!showDatePicker);
   };
 
-  const formatDateForDisplay = (date: Date) => {
-    return date.toLocaleDateString('en-US', {
-      weekday: 'short',
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-    });
-  };
-
   // Convert categories to dropdown options (excluding uncategorized)
   const categoryOptions: DropdownOption[] = categories.map((category) => ({
     label: category.name,
@@ -280,7 +272,7 @@ export default function EditExpenseBottomSheet({
           backgroundColor: theme.colors.surface,
         }}
       >
-        {formatDateForDisplay(date)}
+        {formatDateWithLocale(date, userSetting?.preferredLanguage || 'en')}
       </Button>
       {showDatePicker && (
         <DateTimePicker
@@ -288,6 +280,7 @@ export default function EditExpenseBottomSheet({
           mode="date"
           display={Platform.OS === 'ios' ? 'spinner' : 'default'}
           onChange={handleDateChange}
+          locale={userSetting?.preferredLanguage || 'en'}
           maximumDate={new Date()}
         />
       )}

--- a/mobile/components/BottomSheets/ExpenseBottomSheet.tsx
+++ b/mobile/components/BottomSheets/ExpenseBottomSheet.tsx
@@ -15,6 +15,7 @@ import { getCategoriesByUserId } from '../../db/repository/category';
 import { getPaymentMethodsByUserId } from '../../db/repository/paymentMethod';
 import type { Category, NewExpense, PaymentMethod } from '../../db/schema';
 import { generatedUUID, validateCurrencyInput } from '../../db/utils';
+import { formatDateWithLocale } from '../../utils/datetime';
 import { useRefreshKey } from '../contexts/RefreshKeyContext';
 import { useUser } from '../contexts/UserContext';
 import { BSTextInput } from './BottomSheetTextInput';
@@ -168,15 +169,6 @@ export default function ExpenseBottomSheet({ visible, onDismiss }: ExpenseBottom
     setShowDatePicker(!showDatePicker);
   };
 
-  const formatDateForDisplay = (date: Date) => {
-    return date.toLocaleDateString('en-US', {
-      weekday: 'short',
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-    });
-  };
-
   // Convert categories to dropdown options (excluding uncategorized)
   const categoryOptions: DropdownOption[] = categories.map((category) => ({
     label: category.name,
@@ -251,13 +243,14 @@ export default function ExpenseBottomSheet({ visible, onDismiss }: ExpenseBottom
           backgroundColor: theme.colors.surface,
         }}
       >
-        {formatDateForDisplay(date)}
+        {formatDateWithLocale(date, userSetting?.preferredLanguage || 'en')}
       </Button>
       {showDatePicker && (
         <DateTimePicker
           value={date}
           mode="date"
           display={Platform.OS === 'ios' ? 'spinner' : 'default'}
+          locale={userSetting?.preferredLanguage || 'en'}
           onChange={handleDateChange}
           maximumDate={new Date()}
         />

--- a/mobile/components/BottomSheets/ExpenseDetailBottomSheet.tsx
+++ b/mobile/components/BottomSheets/ExpenseDetailBottomSheet.tsx
@@ -18,6 +18,7 @@ import { getExpenseFullById } from '../../db/repository/expense';
 import type { ExpenseFull } from '../../db/repository/types';
 import type { Expense } from '../../db/schema';
 import { formatAmount } from '../../db/utils';
+import { formatDateWithLocale } from '../../utils/datetime';
 import { useRefreshKey } from '../contexts/RefreshKeyContext';
 import { useUser } from '../contexts/UserContext';
 
@@ -252,12 +253,10 @@ export default function ExpenseDetailBottomSheet({
                     fontWeight: '600',
                   }}
                 >
-                  {new Date(targetExpense.incurredAt).toLocaleDateString('en-US', {
-                    weekday: 'long',
-                    year: 'numeric',
-                    month: 'long',
-                    day: 'numeric',
-                  })}
+                  {formatDateWithLocale(
+                    new Date(targetExpense.incurredAt),
+                    userSetting?.preferredLanguage || 'en',
+                  )}
                 </Text>
               </View>
 
@@ -372,12 +371,10 @@ export default function ExpenseDetailBottomSheet({
                         }}
                       >
                         {t('status.verifiedOn', {
-                          date: new Date(targetExpense.verifiedAt).toLocaleDateString('en-US', {
-                            month: 'short',
-                            day: 'numeric',
-                            hour: '2-digit',
-                            minute: '2-digit',
-                          }),
+                          date: formatDateWithLocale(
+                            new Date(targetExpense.verifiedAt),
+                            userSetting?.preferredLanguage || 'en',
+                          ),
                         })}
                       </Text>
                     )}

--- a/mobile/utils/datetime.ts
+++ b/mobile/utils/datetime.ts
@@ -1,3 +1,5 @@
+import type { SUPPORTED_LANGUAGES } from '../db/schema';
+
 export const getMonthRange = (date: Date) => {
   const start = new Date(date.getFullYear(), date.getMonth(), 1);
   const end = new Date(date.getFullYear(), date.getMonth() + 1, 0, 23, 59, 59, 999);
@@ -6,4 +8,18 @@ export const getMonthRange = (date: Date) => {
     from: start.toISOString(),
     to: end.toISOString(),
   };
+};
+
+export const formatDateWithLocale = (date: Date, locale: (typeof SUPPORTED_LANGUAGES)[number]) => {
+  const localeMap = {
+    en: 'en-US',
+    ja: 'ja-JP',
+  };
+
+  return date.toLocaleDateString(localeMap[locale], {
+    weekday: 'short',
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
 };


### PR DESCRIPTION
## Added localization for date time picker when creating an expense

<!-- A clear, concise title describing your change. -->
<!-- Delete sections or section content as needed -->

### Summary

Feedback was given that the date timepicker does not make sense to a japanese national as it is not in the correct format. This PR adds the capability to show the correct format based on user's preferred language in the application. 

### Related Issues

<!-- Link to any relevant issues or tickets (e.g., Closes #123, Fixes #456) -->

Fixes #179 

### Changes Made

- Abstracted format date with locale to a datetime utils function 
- Updated expense related bottomsheet to use new date time util 
- Updated expense related bottomsheet's date time picker to use locale (although not suggested, i do not want user's to change their phone's language just to see the correct format) 

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have made corresponding changes to documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed

### Additional Context

Add any other relevant context, screenshots, or information for reviewers.

### Reviewer Notes

- Are there specific areas you want feedback on?
- Any known issues or potential risks?
- Is there a particular file or section to focus on?
