### PR TITLE
feat: added eas related makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ include makefiles/init.mk
 # include makefiles/database.mk
 # include makefiles/generator.mk
 include makefiles/runner.mk
+include makefiles/eas.mk
 
 MAKEFLAGS += --no-print-directory
 

--- a/makefiles/eas.mk
+++ b/makefiles/eas.mk
@@ -1,0 +1,16 @@
+##@ EAS CLI Helpers - Commands to interact with eas-cli
+
+.PHONY: build-ios-dev
+build-ios-dev: ## Creates an iOS development build on EAS platform
+	@echo "Starting iOS development build..."
+	@cd ./mobile && eas build --platform ios --profile development
+
+.PHONY: build-ios-prod
+build-ios-prod: ## Creates an iOS production build on EAS platform
+	@echo "Starting iOS production build..."
+	@cd ./mobile && eas build --platform ios --profile production
+
+.PHONY: submit-ios
+submit-ios: ## Submits the iOS build to TestFlight through EAS platform
+	@echo "Submitting to TestFlight..."
+	@cd ./mobile && eas submit --platform ios

--- a/makefiles/runner.mk
+++ b/makefiles/runner.mk
@@ -3,7 +3,7 @@
 .PHONY: run-mobile
 run-mobile: ## Starts mobile servers using Expo (requires emulation)
 	@echo "Starting mobile..."
-	cd ./mobile && bun run dev
+	@cd ./mobile && bun run dev
 
 # .PHONY: run-client
 # run-client: ## Starts the client (web)


### PR DESCRIPTION
## Adds EAS related commands to Makefiles

<!-- A clear, concise title describing your change. -->
<!-- Delete sections or section content as needed -->

### Summary

`eas-cli` commands are verbose, or more like the flags are difficult to remember. This PR adds the necessary commands into an easy to use makefile command for convenience. 

### Related Issues

<!-- Link to any relevant issues or tickets (e.g., Closes #123, Fixes #456) -->

N/A

### Changes Made

- Added eas related makefiles 
- added silence symbols for commands 
