### PR TITLE
feat: add month year selection to home page

### DIFF
--- a/mobile/app/(tabs)/expenses.tsx
+++ b/mobile/app/(tabs)/expenses.tsx
@@ -2,18 +2,20 @@ import { useFocusEffect } from 'expo-router';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ScrollView, View } from 'react-native';
-import { Chip, FAB, Searchbar, Text, useTheme, IconButton } from 'react-native-paper';
+import { Chip, FAB, IconButton, Searchbar, Text, useTheme } from 'react-native-paper';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import EditExpenseBottomSheet from '../../components/BottomSheets/EditExpenseBottomSheet';
 import ExpenseBottomSheet from '../../components/BottomSheets/ExpenseBottomSheet';
 import ExpenseDetailBottomSheet from '../../components/BottomSheets/ExpenseDetailBottomSheet';
-import ExpenseFilterBottomSheet, { ExpenseFilters } from '../../components/BottomSheets/ExpenseFilterBottomSheet';
+import ExpenseFilterBottomSheet, {
+  type ExpenseFilters,
+} from '../../components/BottomSheets/ExpenseFilterBottomSheet';
 import { useRefreshKey } from '../../components/contexts/RefreshKeyContext';
 import { useUser } from '../../components/contexts/UserContext';
 import ErrorBoundary, { ExpensesErrorFallback } from '../../components/ErrorBoundary';
 import ExpenseListItem from '../../components/ExpenseListItem';
 import { getCategoriesByUserId } from '../../db/repository/category';
-import { getExpensesWithDetailsByUserId, getExpensesWithDetailsByUserIdWithFilters } from '../../db/repository/expense';
+import { getExpensesWithDetailsByUserIdWithFilters } from '../../db/repository/expense';
 import { getPaymentMethodsByUserId } from '../../db/repository/paymentMethod';
 import type { ExpenseWithDetails } from '../../db/repository/types';
 import type { Expense } from '../../db/schema';
@@ -40,17 +42,28 @@ export default function ExpensesScreen() {
   // Load all data using our optimized hook - expenses now include category/payment method data
   const { data, loading, error, refetch } = useMultipleAsyncData(
     {
-      expenses: () => (user?.id ? getExpensesWithDetailsByUserIdWithFilters(user.id, {
-        ...activeFilters,
-        searchQuery: searchQuery || undefined,
-        categoryId: selectedCategory || undefined,
-      }) : Promise.resolve([])),
+      expenses: () =>
+        user?.id
+          ? getExpensesWithDetailsByUserIdWithFilters(user.id, {
+              ...activeFilters,
+              searchQuery: searchQuery || undefined,
+              categoryId: selectedCategory || undefined,
+            })
+          : Promise.resolve([]),
       categories: () => (user?.id ? getCategoriesByUserId(user.id) : Promise.resolve([])),
       paymentMethods: () => (user?.id ? getPaymentMethodsByUserId(user.id) : Promise.resolve([])),
     },
     {
       immediate: !!user?.id,
-      deps: [user?.id, refreshKeys.expenses, refreshKeys.categories, refreshKeys.paymentMethods, activeFilters, searchQuery, selectedCategory],
+      deps: [
+        user?.id,
+        refreshKeys.expenses,
+        refreshKeys.categories,
+        refreshKeys.paymentMethods,
+        activeFilters,
+        searchQuery,
+        selectedCategory,
+      ],
     },
   );
 
@@ -213,7 +226,10 @@ export default function ExpensesScreen() {
           </View>
 
           {/* ACTIVE FILTERS */}
-          {(activeFilters.dateRange || activeFilters.verificationStatus || activeFilters.categoryId || selectedCategory) && (
+          {(activeFilters.dateRange ||
+            activeFilters.verificationStatus ||
+            activeFilters.categoryId ||
+            selectedCategory) && (
             <View
               style={{
                 paddingHorizontal: 24,
@@ -266,7 +282,9 @@ export default function ExpensesScreen() {
                       selected
                       onPress={() => setShowFilterSheet(true)}
                     >
-                      {activeFilters.verificationStatus === 'verified' ? t('expenses.filters.verified') : t('expenses.filters.unverified')}
+                      {activeFilters.verificationStatus === 'verified'
+                        ? t('expenses.filters.verified')
+                        : t('expenses.filters.unverified')}
                     </Chip>
                   )}
 
@@ -276,7 +294,9 @@ export default function ExpensesScreen() {
                       selected
                       onPress={() => setShowFilterSheet(true)}
                     >
-                      {data?.categories?.find(cat => cat.id === (activeFilters.categoryId || selectedCategory))?.name || 'Unknown Category'}
+                      {data?.categories?.find(
+                        (cat) => cat.id === (activeFilters.categoryId || selectedCategory),
+                      )?.name || 'Unknown Category'}
                     </Chip>
                   )}
                 </View>

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -1,9 +1,10 @@
 import { useFocusEffect } from 'expo-router';
 import { useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ScrollView } from 'react-native';
-import { Divider, FAB, useTheme } from 'react-native-paper';
+import { ScrollView, View } from 'react-native';
+import { Divider, FAB, IconButton, Text, useTheme } from 'react-native-paper';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import DateSelectorBottomSheet from '../../components/BottomSheets/DateSelectorBottomSheet';
 import EditExpenseBottomSheet from '../../components/BottomSheets/EditExpenseBottomSheet';
 import ExpenseBottomSheet from '../../components/BottomSheets/ExpenseBottomSheet';
 import ExpenseDetailBottomSheet from '../../components/BottomSheets/ExpenseDetailBottomSheet';
@@ -17,8 +18,14 @@ export default function HomePage() {
   const [showExpenseSheet, setShowExpenseSheet] = useState(false);
   const [showDetailSheet, setShowDetailSheet] = useState(false);
   const [showEditSheet, setShowEditSheet] = useState(false);
+  const [showDateSelector, setShowDateSelector] = useState(false);
   const [selectedExpenseId, setSelectedExpenseId] = useState<string | null>(null);
   const [isTransitioningToEdit, setIsTransitioningToEdit] = useState(false);
+
+  // Date selection state
+  const [selectedMonth, setSelectedMonth] = useState(() => new Date().getMonth());
+  const [selectedYear, setSelectedYear] = useState(() => new Date().getFullYear());
+
   const theme = useTheme();
   const { t } = useTranslation();
   const timeoutRef = useRef<number | null>(null);
@@ -29,8 +36,14 @@ export default function HomePage() {
       setShowExpenseSheet(false);
       setShowDetailSheet(false);
       setShowEditSheet(false);
+      setShowDateSelector(false);
       setSelectedExpenseId(null);
       setIsTransitioningToEdit(false);
+
+      // Reset to current month when navigating to this tab
+      const now = new Date();
+      setSelectedMonth(now.getMonth());
+      setSelectedYear(now.getFullYear());
 
       // Cleanup timeout on unmount
       return () => {
@@ -91,69 +104,125 @@ export default function HomePage() {
     setSelectedExpenseId(null);
   };
 
+  const handleDateSelection = useCallback((month: number, year: number) => {
+    setSelectedMonth(month);
+    setSelectedYear(year);
+  }, []);
+
   return (
     <ErrorBoundary
       onError={(error, errorInfo) => {
         console.error('Dashboard error:', error, errorInfo);
       }}
     >
-      <SafeAreaView
-        style={{ flex: 1, backgroundColor: theme.colors.background }}
-        edges={['top', 'left', 'right']}
-      >
-        <ScrollView
+      <View style={{ flex: 1, backgroundColor: theme.colors.surface }}>
+        <SafeAreaView
           style={{ flex: 1, backgroundColor: theme.colors.background }}
-          contentContainerStyle={{ padding: 24, paddingBottom: 100, gap: 16 }}
-          showsVerticalScrollIndicator={false}
+          edges={['top', 'left', 'right']}
         >
-          <BudgetOverview />
-          <CategoriesBreakdown />
-          <Divider />
-          <RecentTransactions onPress={handleExpensePress} />
-        </ScrollView>
+          <View
+            style={{
+              paddingTop: 16,
+              paddingHorizontal: 24,
+              paddingBottom: 16,
+              backgroundColor: theme.colors.background,
+            }}
+          >
+            <View
+              style={{
+                flexDirection: 'row',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+              }}
+            >
+              <Text
+                variant="headlineMedium"
+                style={{
+                  fontWeight: '700',
+                  color: theme.colors.onBackground,
+                }}
+              >
+                {t('navigation.home')}
+              </Text>
+              <IconButton
+                icon="calendar"
+                size={24}
+                onPress={() => setShowDateSelector(true)}
+                iconColor={theme.colors.onBackground}
+              />
+            </View>
+          </View>
+          <ScrollView
+            style={{ flex: 1, backgroundColor: theme.colors.background }}
+            contentContainerStyle={{ padding: 24, paddingBottom: 100, gap: 16 }}
+            showsVerticalScrollIndicator={false}
+          >
+            <BudgetOverview
+              selectedMonth={selectedMonth}
+              selectedYear={selectedYear}
+            />
+            <CategoriesBreakdown
+              selectedMonth={selectedMonth}
+              selectedYear={selectedYear}
+            />
+            <Divider />
+            <RecentTransactions
+              onPress={handleExpensePress}
+              selectedMonth={selectedMonth}
+              selectedYear={selectedYear}
+            />
+          </ScrollView>
 
-        {/* PERIPHERALS */}
-        <FAB
-          icon="plus"
-          label={t('home.newExpense')}
-          onPress={() => {
-            setShowExpenseSheet(true);
-          }}
-          style={{
-            position: 'absolute',
-            bottom: 16,
-            right: 16,
-          }}
-        />
-        <ExpenseBottomSheet
-          visible={showExpenseSheet}
-          onDismiss={() => {
-            setShowExpenseSheet(false);
-          }}
-        />
-        <ExpenseDetailBottomSheet
-          visible={showDetailSheet}
-          expenseId={selectedExpenseId}
-          onDismiss={() => {
-            setShowDetailSheet(false);
-            if (!isTransitioningToEdit) {
+          {/* PERIPHERALS */}
+          <FAB
+            icon="plus"
+            label={t('home.newExpense')}
+            onPress={() => {
+              setShowExpenseSheet(true);
+            }}
+            style={{
+              position: 'absolute',
+              bottom: 16,
+              right: 16,
+            }}
+          />
+          <ExpenseBottomSheet
+            visible={showExpenseSheet}
+            onDismiss={() => {
+              setShowExpenseSheet(false);
+            }}
+          />
+          <ExpenseDetailBottomSheet
+            visible={showDetailSheet}
+            expenseId={selectedExpenseId}
+            onDismiss={() => {
+              setShowDetailSheet(false);
+              if (!isTransitioningToEdit) {
+                setSelectedExpenseId(null);
+              }
+            }}
+            onEdit={handleEditExpense}
+            onDeleted={handleExpenseDeleted}
+          />
+          <EditExpenseBottomSheet
+            visible={showEditSheet}
+            expenseId={selectedExpenseId}
+            onDismiss={() => {
+              setShowEditSheet(false);
               setSelectedExpenseId(null);
-            }
-          }}
-          onEdit={handleEditExpense}
-          onDeleted={handleExpenseDeleted}
-        />
-        <EditExpenseBottomSheet
-          visible={showEditSheet}
-          expenseId={selectedExpenseId}
-          onDismiss={() => {
-            setShowEditSheet(false);
-            setSelectedExpenseId(null);
-            setIsTransitioningToEdit(false);
-          }}
-          onExpenseUpdated={handleExpenseUpdated}
-        />
-      </SafeAreaView>
+              setIsTransitioningToEdit(false);
+            }}
+            onExpenseUpdated={handleExpenseUpdated}
+          />
+          <DateSelectorBottomSheet
+            visible={showDateSelector}
+            onDismiss={() => setShowDateSelector(false)}
+            onApply={handleDateSelection}
+            selectedMonth={selectedMonth}
+            selectedYear={selectedYear}
+          />
+        </SafeAreaView>
+      </View>
     </ErrorBoundary>
   );
 }

--- a/mobile/app/(tabs)/profile/budget-categories.tsx
+++ b/mobile/app/(tabs)/profile/budget-categories.tsx
@@ -18,7 +18,8 @@ import EditCategoryBottomSheet from '../../../components/BottomSheets/EditCatego
 import { useRefreshKey } from '../../../components/contexts/RefreshKeyContext';
 import { useUser } from '../../../components/contexts/UserContext';
 import ErrorBoundary, { LoadingErrorFallback } from '../../../components/ErrorBoundary';
-import { deleteCategoryById, getCategoriesByUserId } from '../../../db/repository/category';
+import { deleteCategoryById } from '../../../db/mutation/category';
+import { getCategoriesByUserId } from '../../../db/repository/category';
 import type { Category } from '../../../db/schema';
 import { formatAmount } from '../../../db/utils';
 import { useUserData } from '../../../hooks/useAsyncData';

--- a/mobile/app/(tabs)/profile/index.tsx
+++ b/mobile/app/(tabs)/profile/index.tsx
@@ -51,7 +51,6 @@ export default function ProfileScreen() {
               variant="headlineMedium"
               style={{
                 fontWeight: '700',
-                marginBottom: 16,
                 color: theme.colors.onBackground,
               }}
             >
@@ -71,6 +70,7 @@ export default function ProfileScreen() {
                 borderWidth: 1,
                 borderColor: theme.colors.outline,
                 overflow: 'hidden',
+                marginTop: 8,
               }}
             >
               <List.Item

--- a/mobile/app/(tabs)/profile/payment-methods.tsx
+++ b/mobile/app/(tabs)/profile/payment-methods.tsx
@@ -19,10 +19,8 @@ import PaymentMethodBottomSheet from '../../../components/BottomSheets/PaymentMe
 import { useRefreshKey } from '../../../components/contexts/RefreshKeyContext';
 import { useUser } from '../../../components/contexts/UserContext';
 import ErrorBoundary, { LoadingErrorFallback } from '../../../components/ErrorBoundary';
-import {
-  deletePaymentMethodById,
-  getPaymentMethodsByUserId,
-} from '../../../db/repository/paymentMethod';
+import { deletePaymentMethodById } from '../../../db/mutation/paymentMethod';
+import { getPaymentMethodsByUserId } from '../../../db/repository/paymentMethod';
 import type { PaymentMethod } from '../../../db/schema';
 import { useUserData } from '../../../hooks/useAsyncData';
 

--- a/mobile/assets/lang/en.json
+++ b/mobile/assets/lang/en.json
@@ -18,6 +18,7 @@
 		"select": "Select",
 		"none": "None",
 		"all": "All",
+		"apply": "Apply",
 		"today": "Today",
 		"yesterday": "Yesterday",
 		"thisWeek": "This Week",
@@ -138,13 +139,16 @@
 		"greatProgress": "Great! You have plenty of budget remaining.",
 		"noBudgetCategories": "No budget categories found",
 		"setupCategories": "Set up budget categories in your profile to start tracking expenses.",
-		"newExpense": "New Expense"
+		"newExpense": "New Expense",
+		"selectPeriod": "Select Period",
+		"selectedPeriod": "Selected Period",
+		"currentMonth": "Current Month",
+		"selectMonth": "Select Month",
+		"selectYear": "Select Year"
 	},
 	"forms": {
 		"title": "Title",
 		"description": "Description",
-		"amount": "Amount",
-		"budget": "Budget",
 		"name": "Name",
 		"type": "Type",
 		"required": "Required",
@@ -174,23 +178,25 @@
 		"selectPaymentType": "Select Payment Type",
 		"paymentType": "Payment Type",
 		"descriptionOptional": "Description (optional)",
-		"amountCurrency": "Amount ({{currency}})", 
-    "amount" : { 
-      "validNumber": "Please enter a valid amount", 
-      "postiveOnly": "Amount cannot be negative", 
-      "largerThanZero": "Amount must be greater than zero",
-      "disallowDecimals": "{{currency}} amounts cannot have decimal place", 
-      "upToDecimalPlaces": "{{currency}} amounts can have at most {{decimals}} decimal places", 
-      "valueTooLarge": "Budget is too large" 
-    }, 
-    "budget": { 
-      "validNumber": "Please enter a valid budget", 
-      "postiveOnly": "Budget cannot be negative", 
-      "largerThanZero": "Budget must be greater than zero",
-      "disallowDecimals": "{{currency}} budgets cannot have decimal place", 
-      "upToDecimalPlaces": "{{currency}} budgets can have at most {{decimals}} decimal places", 
-      "valueTooLarge": "Budget is too large" 
-    }
+		"amountCurrency": "Amount ({{currency}})",
+		"amount": {
+      "amount": "Amount",
+			"validNumber": "Please enter a valid amount",
+			"postiveOnly": "Amount cannot be negative",
+			"largerThanZero": "Amount must be greater than zero",
+			"disallowDecimals": "{{currency}} amounts cannot have decimal place",
+			"upToDecimalPlaces": "{{currency}} amounts can have at most {{decimals}} decimal places",
+			"valueTooLarge": "Budget is too large"
+		},
+		"budget": {
+      "budget": "budget", 
+			"validNumber": "Please enter a valid budget",
+			"postiveOnly": "Budget cannot be negative",
+			"largerThanZero": "Budget must be greater than zero",
+			"disallowDecimals": "{{currency}} budgets cannot have decimal place",
+			"upToDecimalPlaces": "{{currency}} budgets can have at most {{decimals}} decimal places",
+			"valueTooLarge": "Budget is too large"
+		}
 	},
 	"actions": {
 		"create": "Create",

--- a/mobile/assets/lang/ja.json
+++ b/mobile/assets/lang/ja.json
@@ -18,6 +18,7 @@
 		"select": "選択",
 		"none": "なし",
 		"all": "すべて",
+		"apply": "適用",
 		"today": "今日",
 		"yesterday": "昨日",
 		"thisWeek": "今週",
@@ -138,13 +139,16 @@
 		"greatProgress": "素晴らしい！まだ予算に余裕があります。",
 		"noBudgetCategories": "予算カテゴリが見つかりません",
 		"setupCategories": "支出の追跡を始めるには、プロフィールで予算カテゴリを設定してください。",
-		"newExpense": "新しい支出"
+		"newExpense": "新しい支出",
+		"selectPeriod": "期間を選択",
+		"selectedPeriod": "選択された期間",
+		"currentMonth": "今月",
+		"selectMonth": "月を選択",
+		"selectYear": "年を選択"
 	},
 	"forms": {
 		"title": "タイトル",
 		"description": "説明",
-		"amount": "金額",
-		"budget": "予算",
 		"name": "名前",
 		"type": "タイプ",
 		"required": "必須",
@@ -175,22 +179,24 @@
 		"paymentType": "支払いタイプ",
 		"descriptionOptional": "説明（任意）",
 		"amountCurrency": "金額 ({{currency}})",
-    "amount": {
-      "validNumber": "有効な金額を入力してください",
-      "postiveOnly": "金額はマイナスにできません",
-      "largerThanZero": "金額はゼロより大きくなければなりません",
-      "disallowDecimals": "{{currency}}の金額には小数点は使用できません",
-      "upToDecimalPlaces": "{{currency}}の金額は最大で{{decimals}}桁の小数点まで許可されています",
-      "valueTooLarge": "予算が大きすぎます"
-    },
-    "budget": {
-      "validNumber": "有効な予算を入力してください",
-      "postiveOnly": "予算はマイナスにできません",
-      "largerThanZero": "予算はゼロより大きくなければなりません",
-      "disallowDecimals": "{{currency}}の予算には小数点は使用できません",
-      "upToDecimalPlaces": "{{currency}}の予算は最大で{{decimals}}桁の小数点まで許可されています",
-      "valueTooLarge": "予算が大きすぎます"
-    }
+		"amount": {
+      "amount": "金額",
+			"validNumber": "有効な金額を入力してください",
+			"postiveOnly": "金額はマイナスにできません",
+			"largerThanZero": "金額はゼロより大きくなければなりません",
+			"disallowDecimals": "{{currency}}の金額には小数点は使用できません",
+			"upToDecimalPlaces": "{{currency}}の金額は最大で{{decimals}}桁の小数点まで許可されています",
+			"valueTooLarge": "予算が大きすぎます"
+		},
+		"budget": {
+      "budget": "予算",
+			"validNumber": "有効な予算を入力してください",
+			"postiveOnly": "予算はマイナスにできません",
+			"largerThanZero": "予算はゼロより大きくなければなりません",
+			"disallowDecimals": "{{currency}}の予算には小数点は使用できません",
+			"upToDecimalPlaces": "{{currency}}の予算は最大で{{decimals}}桁の小数点まで許可されています",
+			"valueTooLarge": "予算が大きすぎます"
+		}
 	},
 	"actions": {
 		"create": "作成",

--- a/mobile/components/BottomSheets/CategoryBottomSheet.tsx
+++ b/mobile/components/BottomSheets/CategoryBottomSheet.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { Keyboard, View } from 'react-native';
 import { Button, Text, useTheme } from 'react-native-paper';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { createCategory } from '../../db/repository/category';
+import { createCategory } from '../../db/mutation/category';
 import { validateCurrencyInput } from '../../db/utils';
 import { useRefreshKey } from '../contexts/RefreshKeyContext';
 import { useUser } from '../contexts/UserContext';

--- a/mobile/components/BottomSheets/DateSelectorBottomSheet.tsx
+++ b/mobile/components/BottomSheets/DateSelectorBottomSheet.tsx
@@ -107,11 +107,9 @@ export default function DateSelectorBottomSheet({
     return months;
   }, [userSetting?.preferredLanguage]);
 
-  // Generate year options (current year -10 to +3)
   const yearOptions: DropdownOption[] = useMemo(() => {
-    const currentYear = new Date().getFullYear();
     const years = [];
-    for (let year = currentYear - 10; year <= currentYear + 3; year++) {
+    for (let year = 2000; year <= 2050; year++) {
       years.push({
         label: year.toString(),
         value: year.toString(),
@@ -124,51 +122,69 @@ export default function DateSelectorBottomSheet({
   const selectedMonthLabel = monthOptions.find((m) => m.value === tempMonth.toString())?.label;
   const selectedYearLabel = yearOptions.find((y) => y.value === tempYear.toString())?.label;
 
-  const renderMonthDropdown = () => (
-    <>
-      <DropdownButton
-        onPress={() => setShowMonthDropdown(true)}
-        selectedValue={tempMonth.toString()}
-        options={monthOptions}
-        placeholder={t('home.selectMonth')}
-        label={t('home.selectMonth')}
-      />
-      <DropdownBottomSheet
-        visible={showMonthDropdown}
-        onDismiss={() => setShowMonthDropdown(false)}
-        options={monthOptions}
-        onSelect={(value) => {
-          setTempMonth(parseInt(value));
-          setShowMonthDropdown(false);
-        }}
-        selectedValue={tempMonth.toString()}
-        title={t('home.selectMonth')}
-      />
-    </>
-  );
+  const renderMonthDropdown = () => {
+    // Calculate the index of the current month for auto-scrolling
+    const currentMonth = new Date().getMonth();
+    const currentMonthIndex = monthOptions.findIndex(
+      (option) => parseInt(option.value) === currentMonth,
+    );
 
-  const renderYearDropdown = () => (
-    <>
-      <DropdownButton
-        onPress={() => setShowYearDropdown(true)}
-        selectedValue={tempYear.toString()}
-        options={yearOptions}
-        placeholder={t('home.selectYear')}
-        label={t('home.selectYear')}
-      />
-      <DropdownBottomSheet
-        visible={showYearDropdown}
-        onDismiss={() => setShowYearDropdown(false)}
-        options={yearOptions}
-        onSelect={(value) => {
-          setTempYear(parseInt(value));
-          setShowYearDropdown(false);
-        }}
-        selectedValue={tempYear.toString()}
-        title={t('home.selectYear')}
-      />
-    </>
-  );
+    return (
+      <>
+        <DropdownButton
+          onPress={() => setShowMonthDropdown(true)}
+          selectedValue={tempMonth.toString()}
+          options={monthOptions}
+          placeholder={t('home.selectMonth')}
+          label={t('home.selectMonth')}
+        />
+        <DropdownBottomSheet
+          visible={showMonthDropdown}
+          onDismiss={() => setShowMonthDropdown(false)}
+          options={monthOptions}
+          onSelect={(value) => {
+            setTempMonth(parseInt(value));
+            setShowMonthDropdown(false);
+          }}
+          selectedValue={tempMonth.toString()}
+          title={t('home.selectMonth')}
+          scrollToIndex={currentMonthIndex >= 0 ? currentMonthIndex : 0}
+        />
+      </>
+    );
+  };
+
+  const renderYearDropdown = () => {
+    // Calculate the index of the current year for auto-scrolling
+    const currentYear = new Date().getFullYear();
+    const currentYearIndex = yearOptions.findIndex(
+      (option) => parseInt(option.value) === currentYear,
+    );
+
+    return (
+      <>
+        <DropdownButton
+          onPress={() => setShowYearDropdown(true)}
+          selectedValue={tempYear.toString()}
+          options={yearOptions}
+          placeholder={t('home.selectYear')}
+          label={t('home.selectYear')}
+        />
+        <DropdownBottomSheet
+          visible={showYearDropdown}
+          onDismiss={() => setShowYearDropdown(false)}
+          options={yearOptions}
+          onSelect={(value) => {
+            setTempYear(parseInt(value));
+            setShowYearDropdown(false);
+          }}
+          selectedValue={tempYear.toString()}
+          title={t('home.selectYear')}
+          scrollToIndex={currentYearIndex >= 0 ? currentYearIndex : 0}
+        />
+      </>
+    );
+  };
 
   return (
     <BottomSheetModal

--- a/mobile/components/BottomSheets/DateSelectorBottomSheet.tsx
+++ b/mobile/components/BottomSheets/DateSelectorBottomSheet.tsx
@@ -1,0 +1,305 @@
+import {
+  BottomSheetBackdrop,
+  type BottomSheetBackdropProps,
+  BottomSheetModal,
+  BottomSheetScrollView,
+} from '@gorhom/bottom-sheet';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Dimensions, View } from 'react-native';
+import { Button, Text, useTheme } from 'react-native-paper';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useUser } from '../contexts/UserContext';
+import DropdownBottomSheet, { DropdownButton, type DropdownOption } from './DropdownBottomSheet';
+
+interface DateSelectorBottomSheetProps {
+  visible: boolean;
+  onDismiss: () => void;
+  onApply: (month: number, year: number) => void;
+  selectedMonth: number;
+  selectedYear: number;
+}
+
+export default function DateSelectorBottomSheet({
+  visible,
+  onDismiss,
+  onApply,
+  selectedMonth,
+  selectedYear,
+}: DateSelectorBottomSheetProps) {
+  const [tempMonth, setTempMonth] = useState(selectedMonth);
+  const [tempYear, setTempYear] = useState(selectedYear);
+  const [showMonthDropdown, setShowMonthDropdown] = useState(false);
+  const [showYearDropdown, setShowYearDropdown] = useState(false);
+
+  const theme = useTheme();
+  const { t } = useTranslation();
+  const { userSetting } = useUser();
+  const bottomSheetModalRef = useRef<BottomSheetModal>(null);
+
+  // Reset temp values when props change
+  useEffect(() => {
+    setTempMonth(selectedMonth);
+    setTempYear(selectedYear);
+  }, [selectedMonth, selectedYear]);
+
+  useEffect(() => {
+    if (visible) {
+      bottomSheetModalRef.current?.present();
+    } else {
+      bottomSheetModalRef.current?.dismiss();
+    }
+  }, [visible]);
+
+  const handleSheetChanges = useCallback(
+    (index: number) => {
+      if (index === -1) {
+        onDismiss();
+      }
+    },
+    [onDismiss],
+  );
+
+  const renderBackdrop = useCallback(
+    (props: BottomSheetBackdropProps) => (
+      <BottomSheetBackdrop
+        {...props}
+        disappearsOnIndex={-1}
+        appearsOnIndex={0}
+        opacity={0.5}
+        onPress={onDismiss}
+      />
+    ),
+    [onDismiss],
+  );
+
+  const handleApply = useCallback(() => {
+    onApply(tempMonth, tempYear);
+    onDismiss();
+  }, [onApply, tempMonth, tempYear, onDismiss]);
+
+  const handleCurrentMonth = useCallback(() => {
+    const now = new Date();
+    setTempMonth(now.getMonth());
+    setTempYear(now.getFullYear());
+  }, []);
+
+  const handleReset = useCallback(() => {
+    setTempMonth(selectedMonth);
+    setTempYear(selectedYear);
+    onDismiss();
+  }, [selectedMonth, selectedYear, onDismiss]);
+
+  // Generate month options (0-11 for JavaScript Date months)
+  const monthOptions: DropdownOption[] = useMemo(() => {
+    const months = [];
+    for (let i = 0; i < 12; i++) {
+      const date = new Date(2024, i, 1); // Use 2024 as base year for month names
+      months.push({
+        label: date.toLocaleDateString(
+          userSetting?.preferredLanguage === 'ja' ? 'ja-JP' : 'en-US',
+          { month: 'long' },
+        ),
+        value: i.toString(),
+        id: i.toString(),
+      });
+    }
+    return months;
+  }, [userSetting?.preferredLanguage]);
+
+  // Generate year options (current year -10 to +3)
+  const yearOptions: DropdownOption[] = useMemo(() => {
+    const currentYear = new Date().getFullYear();
+    const years = [];
+    for (let year = currentYear - 10; year <= currentYear + 3; year++) {
+      years.push({
+        label: year.toString(),
+        value: year.toString(),
+        id: year.toString(),
+      });
+    }
+    return years;
+  }, []);
+
+  const selectedMonthLabel = monthOptions.find((m) => m.value === tempMonth.toString())?.label;
+  const selectedYearLabel = yearOptions.find((y) => y.value === tempYear.toString())?.label;
+
+  const renderMonthDropdown = () => (
+    <>
+      <DropdownButton
+        onPress={() => setShowMonthDropdown(true)}
+        selectedValue={tempMonth.toString()}
+        options={monthOptions}
+        placeholder={t('home.selectMonth')}
+        label={t('home.selectMonth')}
+      />
+      <DropdownBottomSheet
+        visible={showMonthDropdown}
+        onDismiss={() => setShowMonthDropdown(false)}
+        options={monthOptions}
+        onSelect={(value) => {
+          setTempMonth(parseInt(value));
+          setShowMonthDropdown(false);
+        }}
+        selectedValue={tempMonth.toString()}
+        title={t('home.selectMonth')}
+      />
+    </>
+  );
+
+  const renderYearDropdown = () => (
+    <>
+      <DropdownButton
+        onPress={() => setShowYearDropdown(true)}
+        selectedValue={tempYear.toString()}
+        options={yearOptions}
+        placeholder={t('home.selectYear')}
+        label={t('home.selectYear')}
+      />
+      <DropdownBottomSheet
+        visible={showYearDropdown}
+        onDismiss={() => setShowYearDropdown(false)}
+        options={yearOptions}
+        onSelect={(value) => {
+          setTempYear(parseInt(value));
+          setShowYearDropdown(false);
+        }}
+        selectedValue={tempYear.toString()}
+        title={t('home.selectYear')}
+      />
+    </>
+  );
+
+  return (
+    <BottomSheetModal
+      ref={bottomSheetModalRef}
+      index={0}
+      onChange={handleSheetChanges}
+      enablePanDownToClose
+      enableDynamicSizing
+      backgroundStyle={{ backgroundColor: theme.colors.surface }}
+      handleIndicatorStyle={{ backgroundColor: theme.colors.onSurfaceVariant }}
+      backdropComponent={renderBackdrop}
+      maxDynamicContentSize={Dimensions.get('window').height * 0.9}
+      enableContentPanningGesture
+    >
+      <BottomSheetScrollView
+        contentContainerStyle={{ padding: 16 }}
+        showsVerticalScrollIndicator={false}
+      >
+        <SafeAreaView
+          edges={['bottom']}
+          style={{ flex: 1 }}
+        >
+          <View
+            style={{
+              padding: 8,
+              backgroundColor: theme.colors.surface,
+            }}
+          >
+            <Text
+              variant="headlineMedium"
+              style={{
+                marginBottom: 32,
+                fontWeight: '700',
+                color: theme.colors.onSurface,
+                textAlign: 'center',
+              }}
+            >
+              {t('home.selectPeriod')}
+            </Text>
+            <View
+              style={{
+                backgroundColor: theme.colors.surfaceVariant,
+                padding: 16,
+                borderRadius: 8,
+                marginBottom: 24,
+                alignItems: 'center',
+              }}
+            >
+              <Text
+                variant="bodyMedium"
+                style={{
+                  color: theme.colors.onSurfaceVariant,
+                  marginBottom: 4,
+                }}
+              >
+                {t('home.selectedPeriod')}
+              </Text>
+              <Text
+                variant="titleMedium"
+                style={{
+                  fontWeight: '600',
+                  color: theme.colors.onSurface,
+                }}
+              >
+                {selectedMonthLabel} {selectedYearLabel}
+              </Text>
+            </View>
+            <Button
+              mode="outlined"
+              onPress={handleCurrentMonth}
+              style={{
+                marginBottom: 24,
+                borderRadius: 6,
+              }}
+              icon="calendar-today"
+            >
+              {t('home.currentMonth')}
+            </Button>
+            <View style={{ marginBottom: 16 }}>{renderMonthDropdown()}</View>
+            <View style={{ marginBottom: 32 }}>{renderYearDropdown()}</View>
+            <View
+              style={{
+                flexDirection: 'row',
+                gap: 12,
+              }}
+            >
+              <Button
+                mode="outlined"
+                onPress={handleReset}
+                contentStyle={{
+                  paddingVertical: 4,
+                }}
+                labelStyle={{
+                  fontSize: 16,
+                  fontWeight: '600',
+                  letterSpacing: 0.25,
+                }}
+                style={{
+                  flex: 1,
+                  borderRadius: 6,
+                }}
+              >
+                {t('common.cancel')}
+              </Button>
+              <Button
+                mode="contained"
+                onPress={handleApply}
+                contentStyle={{
+                  paddingVertical: 4,
+                }}
+                labelStyle={{
+                  fontSize: 16,
+                  fontWeight: '600',
+                  letterSpacing: 0.25,
+                }}
+                style={{
+                  flex: 1,
+                  borderRadius: 6,
+                  shadowColor: '#000000',
+                  shadowOffset: { width: 0, height: 2 },
+                  shadowOpacity: 0.1,
+                  shadowRadius: 4,
+                  elevation: 2,
+                }}
+              >
+                {t('common.apply')}
+              </Button>
+            </View>
+          </View>
+        </SafeAreaView>
+      </BottomSheetScrollView>
+    </BottomSheetModal>
+  );
+}

--- a/mobile/components/BottomSheets/DropdownBottomSheet.tsx
+++ b/mobile/components/BottomSheets/DropdownBottomSheet.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { ScrollView, View } from 'react-native';
 import {
   Button,
@@ -25,6 +26,7 @@ interface DropdownDialogProps {
   title: string;
   placeholder?: string;
   label?: string;
+  scrollToIndex?: number; // New prop for auto-scrolling
 }
 
 interface DropdownButtonProps {
@@ -90,13 +92,30 @@ export default function DropdownBottomSheet({
   onSelect,
   selectedValue,
   title,
+  scrollToIndex,
 }: DropdownDialogProps) {
   const theme = useTheme();
+  const scrollViewRef = useRef<ScrollView>(null);
 
   const handleSelect = (value: string) => {
     onSelect(value);
     onDismiss();
   };
+
+  // Auto-scroll to specified index when dropdown opens
+  useEffect(() => {
+    if (visible && scrollToIndex !== undefined && scrollToIndex >= 0) {
+      // Small delay to ensure the modal is fully rendered
+      const timer = setTimeout(() => {
+        scrollViewRef.current?.scrollTo({
+          y: (scrollToIndex - 10) * 56, // Approximate height of each item + separator
+          animated: true,
+        });
+      }, 100);
+
+      return () => clearTimeout(timer);
+    }
+  }, [visible, scrollToIndex]);
 
   const renderItem = ({ item }: { item: DropdownOption }) => (
     <List.Item
@@ -156,6 +175,7 @@ export default function DropdownBottomSheet({
         <Divider style={{ marginVertical: 12 }} />
 
         <ScrollView
+          ref={scrollViewRef}
           showsVerticalScrollIndicator={options.length > 7} // Only show scrollbar if needed
           nestedScrollEnabled={true}
         >

--- a/mobile/components/BottomSheets/EditCategoryBottomSheet.tsx
+++ b/mobile/components/BottomSheets/EditCategoryBottomSheet.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { Keyboard, View } from 'react-native';
 import { Button, Text, useTheme } from 'react-native-paper';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { updateCategory } from '../../db/repository/category';
+import { updateCategory } from '../../db/mutation/category';
 import type { Category } from '../../db/schema';
 import { validateCurrencyInput } from '../../db/utils';
 import { useRefreshKey } from '../contexts/RefreshKeyContext';

--- a/mobile/components/BottomSheets/EditPaymentMethodBottomSheet.tsx
+++ b/mobile/components/BottomSheets/EditPaymentMethodBottomSheet.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next';
 import { Keyboard, View } from 'react-native';
 import { Button, Text, useTheme } from 'react-native-paper';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { updatePaymentMethod } from '../../db/repository/paymentMethod';
+import { updatePaymentMethod } from '../../db/mutation/paymentMethod';
 import type { PaymentMethod } from '../../db/schema';
 import { useRefreshKey } from '../contexts/RefreshKeyContext';
 import { BSTextInput } from './BottomSheetTextInput';

--- a/mobile/components/BottomSheets/ExpenseDetailBottomSheet.tsx
+++ b/mobile/components/BottomSheets/ExpenseDetailBottomSheet.tsx
@@ -219,7 +219,7 @@ export default function ExpenseDetailBottomSheet({
                     fontWeight: '600',
                   }}
                 >
-                  {t('forms.amount')}
+                  {t('forms.amount.amount')}
                 </Text>
                 <Text
                   variant="headlineSmall"
@@ -488,7 +488,8 @@ export default function ExpenseDetailBottomSheet({
               variant="bodySmall"
               style={{ color: theme.colors.onSurfaceVariant, marginBottom: 8 }}
             >
-              {t('forms.amount')}: {targetExpense ? formatAmountLocal(targetExpense.amount) : ''}
+              {t('forms.amount.amount')}:
+              {targetExpense ? formatAmountLocal(targetExpense.amount) : ''}
             </Text>
             <Text
               variant="bodySmall"

--- a/mobile/components/BottomSheets/ExpenseFilterBottomSheet.tsx
+++ b/mobile/components/BottomSheets/ExpenseFilterBottomSheet.tsx
@@ -1,24 +1,22 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { Dimensions, Platform, View } from 'react-native';
-import { format } from 'date-fns';
-import DateTimePicker, { DateTimePickerEvent } from '@react-native-community/datetimepicker';
 import {
-  BottomSheetModal,
   BottomSheetBackdrop,
-  BottomSheetBackdropProps,
+  type BottomSheetBackdropProps,
+  BottomSheetModal,
   BottomSheetScrollView,
 } from '@gorhom/bottom-sheet';
-import { Button } from 'react-native-paper';
-import { SafeAreaView } from 'react-native-safe-area-context';
-import { useTranslation } from 'react-i18next';
-import { Text, useTheme } from 'react-native-paper';
+import DateTimePicker, { type DateTimePickerEvent } from '@react-native-community/datetimepicker';
 import { useFocusEffect } from 'expo-router';
-import DropdownBottomSheet, { DropdownOption, DropdownButton } from './DropdownBottomSheet';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Dimensions, Platform, View } from 'react-native';
+import { Button, Text, useTheme } from 'react-native-paper';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { getCategoriesByUserId } from '../../db/repository/category';
 import { useMultipleAsyncData } from '../../hooks/useAsyncData';
-import { useUser } from '../contexts/UserContext';
-import { useRefreshKey } from '../contexts/RefreshKeyContext';
 import { formatDateWithLocale } from '../../utils/datetime';
+import { useRefreshKey } from '../contexts/RefreshKeyContext';
+import { useUser } from '../contexts/UserContext';
+import DropdownBottomSheet, { DropdownButton, type DropdownOption } from './DropdownBottomSheet';
 
 export interface ExpenseFilters {
   dateRange?: {
@@ -50,16 +48,20 @@ export default function ExpenseFilterBottomSheet({
 
   // Local state for form
   const [startDate, setStartDate] = useState<Date>(
-    currentFilters.dateRange?.from ? new Date(currentFilters.dateRange.from) : new Date(new Date().getFullYear(), new Date().getMonth(), 1)
+    currentFilters.dateRange?.from
+      ? new Date(currentFilters.dateRange.from)
+      : new Date(new Date().getFullYear(), new Date().getMonth(), 1),
   );
   const [endDate, setEndDate] = useState<Date>(
-    currentFilters.dateRange?.to ? new Date(currentFilters.dateRange.to) : new Date(new Date().getFullYear(), new Date().getMonth() + 1, 0, 23, 59, 59, 999)
+    currentFilters.dateRange?.to
+      ? new Date(currentFilters.dateRange.to)
+      : new Date(new Date().getFullYear(), new Date().getMonth() + 1, 0, 23, 59, 59, 999),
   );
   const [verificationStatus, setVerificationStatus] = useState<'verified' | 'unverified' | 'all'>(
-    currentFilters.verificationStatus || 'all'
+    currentFilters.verificationStatus || 'all',
   );
   const [selectedCategoryId, setSelectedCategoryId] = useState<string | undefined>(
-    currentFilters.categoryId
+    currentFilters.categoryId,
   );
 
   // Date picker states
@@ -95,10 +97,14 @@ export default function ExpenseFilterBottomSheet({
     useCallback(() => {
       if (visible) {
         setStartDate(
-          currentFilters.dateRange?.from ? new Date(currentFilters.dateRange.from) : new Date(new Date().getFullYear(), new Date().getMonth(), 1)
+          currentFilters.dateRange?.from
+            ? new Date(currentFilters.dateRange.from)
+            : new Date(new Date().getFullYear(), new Date().getMonth(), 1),
         );
         setEndDate(
-          currentFilters.dateRange?.to ? new Date(currentFilters.dateRange.to) : new Date(new Date().getFullYear(), new Date().getMonth() + 1, 0, 23, 59, 59, 999)
+          currentFilters.dateRange?.to
+            ? new Date(currentFilters.dateRange.to)
+            : new Date(new Date().getFullYear(), new Date().getMonth() + 1, 0, 23, 59, 59, 999),
         );
         setVerificationStatus(currentFilters.verificationStatus || 'all');
         setSelectedCategoryId(currentFilters.categoryId);
@@ -193,262 +199,260 @@ export default function ExpenseFilterBottomSheet({
   ];
 
   return (
-    <>
-      <BottomSheetModal
-        ref={bottomSheetModalRef}
-        index={0}
-        onChange={handleSheetChanges}
-        enablePanDownToClose
-        enableDynamicSizing
-        keyboardBehavior="interactive"
-        keyboardBlurBehavior="restore"
-        backgroundStyle={{ backgroundColor: theme.colors.surface }}
-        handleIndicatorStyle={{ backgroundColor: theme.colors.onSurfaceVariant }}
-        maxDynamicContentSize={Dimensions.get('window').height * 0.9}
-        backdropComponent={renderBackdrop}
-        enableContentPanningGesture
+    <BottomSheetModal
+      ref={bottomSheetModalRef}
+      index={0}
+      onChange={handleSheetChanges}
+      enablePanDownToClose
+      enableDynamicSizing
+      keyboardBehavior="interactive"
+      keyboardBlurBehavior="restore"
+      backgroundStyle={{ backgroundColor: theme.colors.surface }}
+      handleIndicatorStyle={{ backgroundColor: theme.colors.onSurfaceVariant }}
+      maxDynamicContentSize={Dimensions.get('window').height * 0.9}
+      backdropComponent={renderBackdrop}
+      enableContentPanningGesture
+    >
+      <BottomSheetScrollView
+        contentContainerStyle={{ padding: 16, paddingBottom: 32 }}
+        keyboardShouldPersistTaps="never"
+        showsVerticalScrollIndicator={false}
+        automaticallyAdjustKeyboardInsets={false}
       >
-        <BottomSheetScrollView
-          contentContainerStyle={{ padding: 16, paddingBottom: 32 }}
-          keyboardShouldPersistTaps="never"
-          showsVerticalScrollIndicator={false}
-          automaticallyAdjustKeyboardInsets={false}
+        <SafeAreaView
+          edges={['bottom']}
+          style={{ flex: 1 }}
         >
-          <SafeAreaView
-            edges={['bottom']}
-            style={{ flex: 1 }}
+          <View
+            style={{
+              padding: 8,
+              backgroundColor: theme.colors.surface,
+            }}
           >
-            <View
+            <Text
+              variant="headlineMedium"
               style={{
-                padding: 8,
-                backgroundColor: theme.colors.surface,
+                marginBottom: 32,
+                fontWeight: '700',
+                color: theme.colors.onSurface,
+                textAlign: 'center',
               }}
             >
-              <Text
-                variant="headlineMedium"
-                style={{
-                  marginBottom: 32,
-                  fontWeight: '700',
-                  color: theme.colors.onSurface,
-                  textAlign: 'center',
-                }}
-              >
-                {t('expenses.filters.title')}
-              </Text>
+              {t('expenses.filters.title')}
+            </Text>
 
-              <View style={{ gap: 24 }}>
-                {/* Date Range Section */}
-                <View>
-                  <Text
-                    variant="labelLarge"
-                    style={{
-                      marginBottom: 16,
-                      color: theme.colors.onSurfaceVariant,
-                      fontWeight: '600',
-                    }}
-                  >
-                    {t('expenses.filters.dateRange')}
-                  </Text>
-                  <View style={{ gap: 12 }}>
-                    <View>
-                      <Text
-                        variant="labelMedium"
-                        style={{
-                          marginBottom: 8,
-                          color: theme.colors.onSurfaceVariant,
-                          fontWeight: '500',
-                        }}
-                      >
-                        {t('expenses.filters.startDate')}
-                      </Text>
-                      <Button
-                        mode="outlined"
-                        onPress={handleStartDatePickerToggle}
-                        contentStyle={{
-                          paddingVertical: 4,
-                          justifyContent: 'flex-start',
-                        }}
-                        labelStyle={{
-                          fontSize: 16,
-                          fontWeight: '500',
-                          textAlign: 'left',
-                        }}
-                        style={{
-                          borderRadius: 6,
-                          borderColor: theme.colors.outline,
-                          backgroundColor: theme.colors.surface,
-                        }}
-                      >
-                        {formatDateWithLocale(startDate, userSetting?.preferredLanguage || 'en')}
-                      </Button>
-                      {showStartDatePicker && (
-                        <DateTimePicker
-                          value={startDate}
-                          mode="date"
-                          display={Platform.OS === 'ios' ? 'spinner' : 'default'}
-                          onChange={handleStartDateChange}
-                          locale={userSetting?.preferredLanguage || 'en'}
-                          maximumDate={endDate}
-                        />
-                      )}
-                    </View>
-                    <View>
-                      <Text
-                        variant="labelMedium"
-                        style={{
-                          marginBottom: 8,
-                          color: theme.colors.onSurfaceVariant,
-                          fontWeight: '500',
-                        }}
-                      >
-                        {t('expenses.filters.endDate')}
-                      </Text>
-                      <Button
-                        mode="outlined"
-                        onPress={handleEndDatePickerToggle}
-                        contentStyle={{
-                          paddingVertical: 4,
-                          justifyContent: 'flex-start',
-                        }}
-                        labelStyle={{
-                          fontSize: 16,
-                          fontWeight: '500',
-                          textAlign: 'left',
-                        }}
-                        style={{
-                          borderRadius: 6,
-                          borderColor: theme.colors.outline,
-                          backgroundColor: theme.colors.surface,
-                        }}
-                      >
-                        {formatDateWithLocale(endDate, userSetting?.preferredLanguage || 'en')}
-                      </Button>
-                      {showEndDatePicker && (
-                        <DateTimePicker
-                          value={endDate}
-                          mode="date"
-                          display={Platform.OS === 'ios' ? 'spinner' : 'default'}
-                          locale={userSetting?.preferredLanguage || 'en'}
-                          onChange={handleEndDateChange}
-                          minimumDate={startDate}
-                          maximumDate={new Date()}
-                        />
-                      )}
-                    </View>
+            <View style={{ gap: 24 }}>
+              {/* Date Range Section */}
+              <View>
+                <Text
+                  variant="labelLarge"
+                  style={{
+                    marginBottom: 16,
+                    color: theme.colors.onSurfaceVariant,
+                    fontWeight: '600',
+                  }}
+                >
+                  {t('expenses.filters.dateRange')}
+                </Text>
+                <View style={{ gap: 12 }}>
+                  <View>
+                    <Text
+                      variant="labelMedium"
+                      style={{
+                        marginBottom: 8,
+                        color: theme.colors.onSurfaceVariant,
+                        fontWeight: '500',
+                      }}
+                    >
+                      {t('expenses.filters.startDate')}
+                    </Text>
+                    <Button
+                      mode="outlined"
+                      onPress={handleStartDatePickerToggle}
+                      contentStyle={{
+                        paddingVertical: 4,
+                        justifyContent: 'flex-start',
+                      }}
+                      labelStyle={{
+                        fontSize: 16,
+                        fontWeight: '500',
+                        textAlign: 'left',
+                      }}
+                      style={{
+                        borderRadius: 6,
+                        borderColor: theme.colors.outline,
+                        backgroundColor: theme.colors.surface,
+                      }}
+                    >
+                      {formatDateWithLocale(startDate, userSetting?.preferredLanguage || 'en')}
+                    </Button>
+                    {showStartDatePicker && (
+                      <DateTimePicker
+                        value={startDate}
+                        mode="date"
+                        display={Platform.OS === 'ios' ? 'spinner' : 'default'}
+                        onChange={handleStartDateChange}
+                        locale={userSetting?.preferredLanguage || 'en'}
+                        maximumDate={endDate}
+                      />
+                    )}
+                  </View>
+                  <View>
+                    <Text
+                      variant="labelMedium"
+                      style={{
+                        marginBottom: 8,
+                        color: theme.colors.onSurfaceVariant,
+                        fontWeight: '500',
+                      }}
+                    >
+                      {t('expenses.filters.endDate')}
+                    </Text>
+                    <Button
+                      mode="outlined"
+                      onPress={handleEndDatePickerToggle}
+                      contentStyle={{
+                        paddingVertical: 4,
+                        justifyContent: 'flex-start',
+                      }}
+                      labelStyle={{
+                        fontSize: 16,
+                        fontWeight: '500',
+                        textAlign: 'left',
+                      }}
+                      style={{
+                        borderRadius: 6,
+                        borderColor: theme.colors.outline,
+                        backgroundColor: theme.colors.surface,
+                      }}
+                    >
+                      {formatDateWithLocale(endDate, userSetting?.preferredLanguage || 'en')}
+                    </Button>
+                    {showEndDatePicker && (
+                      <DateTimePicker
+                        value={endDate}
+                        mode="date"
+                        display={Platform.OS === 'ios' ? 'spinner' : 'default'}
+                        locale={userSetting?.preferredLanguage || 'en'}
+                        onChange={handleEndDateChange}
+                        minimumDate={startDate}
+                        maximumDate={new Date()}
+                      />
+                    )}
                   </View>
                 </View>
+              </View>
 
-                {/* Verification Status Section */}
-                <View>
-                  <Text
-                    variant="labelLarge"
-                    style={{
-                      marginBottom: 16,
-                      color: theme.colors.onSurfaceVariant,
-                      fontWeight: '600',
-                    }}
-                  >
-                    {t('expenses.filters.verificationStatus')}
-                  </Text>
-                  <DropdownButton
-                    onPress={() => setShowVerificationDropdown(true)}
-                    selectedValue={verificationStatus}
-                    options={verificationOptions}
-                    placeholder={t('expenses.filters.selectVerificationStatus')}
-                  />
-                  <DropdownBottomSheet
-                    visible={showVerificationDropdown}
-                    onDismiss={() => setShowVerificationDropdown(false)}
-                    options={verificationOptions}
-                    onSelect={(value) => {
-                      setVerificationStatus(value as 'verified' | 'unverified' | 'all');
-                      setShowVerificationDropdown(false);
-                    }}
-                    selectedValue={verificationStatus}
-                    title={t('expenses.filters.selectVerificationStatus')}
-                  />
-                </View>
+              {/* Verification Status Section */}
+              <View>
+                <Text
+                  variant="labelLarge"
+                  style={{
+                    marginBottom: 16,
+                    color: theme.colors.onSurfaceVariant,
+                    fontWeight: '600',
+                  }}
+                >
+                  {t('expenses.filters.verificationStatus')}
+                </Text>
+                <DropdownButton
+                  onPress={() => setShowVerificationDropdown(true)}
+                  selectedValue={verificationStatus}
+                  options={verificationOptions}
+                  placeholder={t('expenses.filters.selectVerificationStatus')}
+                />
+                <DropdownBottomSheet
+                  visible={showVerificationDropdown}
+                  onDismiss={() => setShowVerificationDropdown(false)}
+                  options={verificationOptions}
+                  onSelect={(value) => {
+                    setVerificationStatus(value as 'verified' | 'unverified' | 'all');
+                    setShowVerificationDropdown(false);
+                  }}
+                  selectedValue={verificationStatus}
+                  title={t('expenses.filters.selectVerificationStatus')}
+                />
+              </View>
 
-                {/* Category Section */}
-                <View>
-                  <Text
-                    variant="labelLarge"
-                    style={{
-                      marginBottom: 16,
-                      color: theme.colors.onSurfaceVariant,
-                      fontWeight: '600',
-                    }}
-                  >
-                    {t('expenses.filters.category')}
-                  </Text>
-                  <DropdownButton
-                    onPress={() => setShowCategoryDropdown(true)}
-                    selectedValue={selectedCategoryId || ''}
-                    options={categoryOptions}
-                    placeholder={t('expenses.filters.selectCategory')}
-                  />
-                  <DropdownBottomSheet
-                    visible={showCategoryDropdown}
-                    onDismiss={() => setShowCategoryDropdown(false)}
-                    options={categoryOptions}
-                    onSelect={(value) => {
-                      setSelectedCategoryId(value || undefined);
-                      setShowCategoryDropdown(false);
-                    }}
-                    selectedValue={selectedCategoryId || ''}
-                    title={t('expenses.filters.selectCategory')}
-                  />
-                </View>
+              {/* Category Section */}
+              <View>
+                <Text
+                  variant="labelLarge"
+                  style={{
+                    marginBottom: 16,
+                    color: theme.colors.onSurfaceVariant,
+                    fontWeight: '600',
+                  }}
+                >
+                  {t('expenses.filters.category')}
+                </Text>
+                <DropdownButton
+                  onPress={() => setShowCategoryDropdown(true)}
+                  selectedValue={selectedCategoryId || ''}
+                  options={categoryOptions}
+                  placeholder={t('expenses.filters.selectCategory')}
+                />
+                <DropdownBottomSheet
+                  visible={showCategoryDropdown}
+                  onDismiss={() => setShowCategoryDropdown(false)}
+                  options={categoryOptions}
+                  onSelect={(value) => {
+                    setSelectedCategoryId(value || undefined);
+                    setShowCategoryDropdown(false);
+                  }}
+                  selectedValue={selectedCategoryId || ''}
+                  title={t('expenses.filters.selectCategory')}
+                />
+              </View>
 
-                {/* Action Buttons */}
-                <View style={{ flexDirection: 'row', gap: 16, marginTop: 16 }}>
-                  <Button
-                    mode="outlined"
-                    onPress={handleClearAll}
-                    contentStyle={{
-                      paddingVertical: 4,
-                    }}
-                    labelStyle={{
-                      fontSize: 16,
-                      fontWeight: '600',
-                      letterSpacing: 0.25,
-                    }}
-                    style={{
-                      flex: 1,
-                      borderRadius: 6,
-                    }}
-                  >
-                    {t('expenses.filters.clearAll')}
-                  </Button>
-                  <Button
-                    mode="contained"
-                    onPress={handleApplyFilters}
-                    contentStyle={{
-                      paddingVertical: 4,
-                    }}
-                    labelStyle={{
-                      fontSize: 16,
-                      fontWeight: '600',
-                      letterSpacing: 0.25,
-                    }}
-                    style={{
-                      flex: 1,
-                      borderRadius: 6,
-                      shadowColor: '#000000',
-                      shadowOffset: { width: 0, height: 2 },
-                      shadowOpacity: 0.1,
-                      shadowRadius: 4,
-                      elevation: 2,
-                    }}
-                  >
-                    {t('expenses.filters.applyFilters')}
-                  </Button>
-                </View>
+              {/* Action Buttons */}
+              <View style={{ flexDirection: 'row', gap: 16, marginTop: 16 }}>
+                <Button
+                  mode="outlined"
+                  onPress={handleClearAll}
+                  contentStyle={{
+                    paddingVertical: 4,
+                  }}
+                  labelStyle={{
+                    fontSize: 16,
+                    fontWeight: '600',
+                    letterSpacing: 0.25,
+                  }}
+                  style={{
+                    flex: 1,
+                    borderRadius: 6,
+                  }}
+                >
+                  {t('expenses.filters.clearAll')}
+                </Button>
+                <Button
+                  mode="contained"
+                  onPress={handleApplyFilters}
+                  contentStyle={{
+                    paddingVertical: 4,
+                  }}
+                  labelStyle={{
+                    fontSize: 16,
+                    fontWeight: '600',
+                    letterSpacing: 0.25,
+                  }}
+                  style={{
+                    flex: 1,
+                    borderRadius: 6,
+                    shadowColor: '#000000',
+                    shadowOffset: { width: 0, height: 2 },
+                    shadowOpacity: 0.1,
+                    shadowRadius: 4,
+                    elevation: 2,
+                  }}
+                >
+                  {t('expenses.filters.applyFilters')}
+                </Button>
               </View>
             </View>
-          </SafeAreaView>
-        </BottomSheetScrollView>
-      </BottomSheetModal>
-    </>
+          </View>
+        </SafeAreaView>
+      </BottomSheetScrollView>
+    </BottomSheetModal>
   );
-} 
+}

--- a/mobile/components/BottomSheets/PaymentMethodBottomSheet.tsx
+++ b/mobile/components/BottomSheets/PaymentMethodBottomSheet.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next';
 import { Keyboard, View } from 'react-native';
 import { Button, Text, useTheme } from 'react-native-paper';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { createPaymentMethod } from '../../db/repository/paymentMethod';
+import { createPaymentMethod } from '../../db/mutation/paymentMethod';
 import { useRefreshKey } from '../contexts/RefreshKeyContext';
 import { useUser } from '../contexts/UserContext';
 import { BSTextInput } from './BottomSheetTextInput';

--- a/mobile/components/Home/BudgetOverview.tsx
+++ b/mobile/components/Home/BudgetOverview.tsx
@@ -5,37 +5,46 @@ import { Divider, Text, useTheme } from 'react-native-paper';
 import { getCategoriesBudgetSumByUserId } from '../../db/repository/category';
 import { getMonthlyExpenseSumByUserId } from '../../db/repository/expense';
 import { formatAmount } from '../../db/utils';
-import { getMonthRange } from '../../utils/datetime';
+import { getMonthRangeByMonthYear } from '../../utils/datetime';
 import { useRefreshKey } from '../contexts/RefreshKeyContext';
 import { useUser } from '../contexts/UserContext';
 
-export const BudgetOverview = () => {
+interface BudgetOverviewProps {
+  selectedMonth: number;
+  selectedYear: number;
+}
+
+export const BudgetOverview = ({ selectedMonth, selectedYear }: BudgetOverviewProps) => {
   const theme = useTheme();
   const { t } = useTranslation();
   const { user, userSetting } = useUser();
   const { refreshKeys } = useRefreshKey();
   const [totalBudget, setTotalBudget] = useState(0);
   const [totalSpent, setTotalSpent] = useState(0);
+  const [loading, setLoading] = useState(false);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: refreshKeys are intentionally used to trigger re-fetching
   useEffect(() => {
     if (!user?.id) return;
 
+    setLoading(true);
     try {
       // Get total budget sum
       const budgetSum = getCategoriesBudgetSumByUserId(user.id);
       setTotalBudget(budgetSum);
 
-      // Get total spent in month
-      const { from, to } = getMonthRange(new Date());
+      // Get total spent in selected month
+      const { from, to } = getMonthRangeByMonthYear(selectedMonth, selectedYear);
       const totalSpent = getMonthlyExpenseSumByUserId(user.id, from, to);
       setTotalSpent(totalSpent);
     } catch (error) {
       console.error('Error fetching budget overview data:', error);
       setTotalBudget(0);
       setTotalSpent(0);
+    } finally {
+      setLoading(false);
     }
-  }, [user?.id, refreshKeys.categories, refreshKeys.expenses]);
+  }, [user?.id, selectedMonth, selectedYear, refreshKeys.categories, refreshKeys.expenses]);
 
   const { remainder, percentUsed } = useMemo(() => {
     const remainder = totalBudget - totalSpent;
@@ -43,8 +52,31 @@ export const BudgetOverview = () => {
     return { remainder, percentUsed: Number(percentUsed.toFixed(2)) };
   }, [totalBudget, totalSpent]);
 
+  const formatSelectedPeriod = useMemo(() => {
+    const date = new Date(selectedYear, selectedMonth, 1);
+    return date.toLocaleDateString(undefined, {
+      month: 'long',
+      year: 'numeric',
+    });
+  }, [selectedMonth, selectedYear]);
+
+  if (loading) {
+    return (
+      <View style={{ paddingVertical: 32, alignItems: 'center' }}>
+        <Text
+          variant="bodyMedium"
+          style={{
+            color: theme.colors.onSurfaceVariant,
+          }}
+        >
+          {t('status.loading')}
+        </Text>
+      </View>
+    );
+  }
+
   return (
-    <View style={{ paddingVertical: 32 }}>
+    <View style={{ paddingBottom: 32, paddingTop: 0 }}>
       {/* Header */}
       <View
         style={{
@@ -71,10 +103,7 @@ export const BudgetOverview = () => {
             opacity: 0.8,
           }}
         >
-          {new Date().toLocaleDateString(undefined, {
-            month: 'long',
-            year: 'numeric',
-          })}
+          {formatSelectedPeriod}
         </Text>
       </View>
 

--- a/mobile/components/Home/CategoriesBreakdown.tsx
+++ b/mobile/components/Home/CategoriesBreakdown.tsx
@@ -4,10 +4,15 @@ import { Text, useTheme } from 'react-native-paper';
 import { useCategoriesBreakdown } from '../../hooks/useCategoriesBreakdown';
 import { CategoryList } from '../CategoryList';
 
-export const CategoriesBreakdown = () => {
+interface CategoriesBreakdownProps {
+  selectedMonth: number;
+  selectedYear: number;
+}
+
+export const CategoriesBreakdown = ({ selectedMonth, selectedYear }: CategoriesBreakdownProps) => {
   const theme = useTheme();
   const { t } = useTranslation();
-  const { categories, loading, error } = useCategoriesBreakdown();
+  const { categories, loading, error } = useCategoriesBreakdown(selectedMonth, selectedYear);
 
   if (error) {
     return (
@@ -49,7 +54,7 @@ export const CategoriesBreakdown = () => {
           variant="bodyMedium"
           style={{ color: theme.colors.onSurfaceVariant }}
         >
-          Loading categories...
+          {t('status.loading')}
         </Text>
       ) : (
         <CategoryList categories={categories} />

--- a/mobile/components/Home/RecentTransactions.tsx
+++ b/mobile/components/Home/RecentTransactions.tsx
@@ -4,7 +4,7 @@ import { Text, useTheme } from 'react-native-paper';
 import { getExpensesInRangeByUserId } from '../../db/repository/expense';
 import type { Expense } from '../../db/schema';
 import { useUserData } from '../../hooks/useAsyncData';
-import { getMonthRange } from '../../utils/datetime';
+import { getMonthRangeByMonthYear } from '../../utils/datetime';
 import { useRefreshKey } from '../contexts/RefreshKeyContext';
 import { useUser } from '../contexts/UserContext';
 import { LoadingErrorFallback } from '../ErrorBoundary';
@@ -12,9 +12,11 @@ import ExpenseList from '../ExpenseList';
 
 interface Props {
   onPress: (expense: Expense) => void;
+  selectedMonth: number;
+  selectedYear: number;
 }
 
-export const RecentTransactions = ({ onPress }: Props) => {
+export const RecentTransactions = ({ onPress, selectedMonth, selectedYear }: Props) => {
   const { t } = useTranslation();
   const theme = useTheme();
   const { user } = useUser();
@@ -28,11 +30,11 @@ export const RecentTransactions = ({ onPress }: Props) => {
     refetch,
   } = useUserData(
     (userId) => {
-      const { from, to } = getMonthRange(new Date());
+      const { from, to } = getMonthRangeByMonthYear(selectedMonth, selectedYear);
       return getExpensesInRangeByUserId(userId, from, to, 10);
     },
     user?.id,
-    [refreshKeys.expenses],
+    [refreshKeys.expenses, selectedMonth, selectedYear],
   );
 
   if (loading) {

--- a/mobile/db/mutation/category.ts
+++ b/mobile/db/mutation/category.ts
@@ -1,0 +1,43 @@
+import { and, eq, isNull } from 'drizzle-orm';
+import * as Crypto from 'expo-crypto';
+import { db } from '../drizzle';
+import type { Category } from '../schema';
+import { category } from '../schema';
+
+export const createCategory = (
+  categoryData: Omit<Category, 'id' | 'createdAt' | 'updatedAt' | 'deletedAt'>,
+) => {
+  const id = Crypto.randomUUID();
+  return db
+    .insert(category)
+    .values({
+      id,
+      ...categoryData,
+    })
+    .returning()
+    .get();
+};
+
+export const updateCategory = (
+  categoryId: string,
+  updates: Partial<Omit<Category, 'id' | 'createdAt' | 'updatedAt' | 'deletedAt'>>,
+) => {
+  return db
+    .update(category)
+    .set(updates)
+    .where(and(eq(category.id, categoryId), isNull(category.deletedAt)))
+    .returning()
+    .get();
+};
+
+export const deleteCategoryById = (categoryId: string) => {
+  // Soft delete by setting deletedAt timestamp
+  return db
+    .update(category)
+    .set({
+      deletedAt: new Date().toISOString(),
+    })
+    .where(and(eq(category.id, categoryId), isNull(category.deletedAt)))
+    .returning()
+    .get();
+};

--- a/mobile/db/mutation/paymentMethod.ts
+++ b/mobile/db/mutation/paymentMethod.ts
@@ -1,20 +1,32 @@
 import { and, eq, isNull } from 'drizzle-orm';
+import * as Crypto from 'expo-crypto';
 import { db } from '../drizzle';
+import type { PaymentMethod } from '../schema';
 import { paymentMethod } from '../schema';
 
-export const getPaymentMethodsByUserId = (userId: string) => {
+export const createPaymentMethod = (
+  paymentMethodData: Omit<PaymentMethod, 'id' | 'createdAt' | 'updatedAt' | 'deletedAt'>,
+) => {
+  const id = Crypto.randomUUID();
   return db
-    .select()
-    .from(paymentMethod)
-    .where(and(eq(paymentMethod.userId, userId), isNull(paymentMethod.deletedAt)))
-    .all();
+    .insert(paymentMethod)
+    .values({
+      id,
+      ...paymentMethodData,
+    })
+    .returning()
+    .get();
 };
 
-export const getPaymentMethodById = (paymentMethodId: string) => {
+export const updatePaymentMethod = (
+  paymentMethodId: string,
+  updates: Partial<Omit<PaymentMethod, 'id' | 'createdAt' | 'updatedAt' | 'deletedAt'>>,
+) => {
   return db
-    .select()
-    .from(paymentMethod)
+    .update(paymentMethod)
+    .set(updates)
     .where(and(eq(paymentMethod.id, paymentMethodId), isNull(paymentMethod.deletedAt)))
+    .returning()
     .get();
 };
 

--- a/mobile/db/repository/category.ts
+++ b/mobile/db/repository/category.ts
@@ -1,7 +1,5 @@
 import { and, eq, isNull } from 'drizzle-orm';
-import * as Crypto from 'expo-crypto';
 import { db } from '../drizzle';
-import type { Category } from '../schema';
 import { category } from '../schema';
 
 export const getCategoriesByUserId = (userId: string) => {
@@ -22,43 +20,5 @@ export const getCategoryById = (categoryId: string) => {
     .select()
     .from(category)
     .where(and(eq(category.id, categoryId), isNull(category.deletedAt)))
-    .get();
-};
-
-export const createCategory = (
-  categoryData: Omit<Category, 'id' | 'createdAt' | 'updatedAt' | 'deletedAt'>,
-) => {
-  const id = Crypto.randomUUID();
-  return db
-    .insert(category)
-    .values({
-      id,
-      ...categoryData,
-    })
-    .returning()
-    .get();
-};
-
-export const updateCategory = (
-  categoryId: string,
-  updates: Partial<Omit<Category, 'id' | 'createdAt' | 'updatedAt' | 'deletedAt'>>,
-) => {
-  return db
-    .update(category)
-    .set(updates)
-    .where(and(eq(category.id, categoryId), isNull(category.deletedAt)))
-    .returning()
-    .get();
-};
-
-export const deleteCategoryById = (categoryId: string) => {
-  // Soft delete by setting deletedAt timestamp
-  return db
-    .update(category)
-    .set({
-      deletedAt: new Date().toISOString(),
-    })
-    .where(and(eq(category.id, categoryId), isNull(category.deletedAt)))
-    .returning()
     .get();
 };

--- a/mobile/db/repository/expense.ts
+++ b/mobile/db/repository/expense.ts
@@ -1,7 +1,7 @@
 import { and, desc, eq, getTableColumns, gte, isNull, lte, sql } from 'drizzle-orm';
 import { db } from '../drizzle';
 import { category, expense, paymentMethod } from '../schema';
-import type { ExpenseFull, ExpenseWithDetails } from './types';
+import type { ExpenseFull, ExpenseWithDetails } from '../types';
 
 export const getMonthlyExpenseSumByUserId = (userId: string, from: string, to: string) => {
   const result = db

--- a/mobile/db/types.ts
+++ b/mobile/db/types.ts
@@ -1,4 +1,4 @@
-import type { Category, Expense, PaymentMethod } from '../schema';
+import type { Category, Expense, PaymentMethod } from './schema';
 
 export interface CategoryWithSpending extends Category {
   spent: number;

--- a/mobile/hooks/useCategoriesBreakdown.ts
+++ b/mobile/hooks/useCategoriesBreakdown.ts
@@ -5,9 +5,12 @@ import { useUser } from '../components/contexts/UserContext';
 import { getCategoriesByUserId } from '../db/repository/category';
 import { getExpensesInRangeByUserId } from '../db/repository/expense';
 import type { CategoryWithSpending } from '../db/repository/types';
-import { getMonthRange } from '../utils/datetime';
+import { getMonthRangeByMonthYear } from '../utils/datetime';
 
-export function useCategoriesBreakdown(): {
+export function useCategoriesBreakdown(
+  selectedMonth: number,
+  selectedYear: number,
+): {
   categories: CategoryWithSpending[];
   loading: boolean;
   error: string | null;
@@ -26,8 +29,8 @@ export function useCategoriesBreakdown(): {
       // Fetch categories (excluding deleted)
       const categories = getCategoriesByUserId(user.id);
 
-      // Fetch this month's expenses (excluding deleted)
-      const { from, to } = getMonthRange(new Date());
+      // Fetch selected month's expenses (excluding deleted)
+      const { from, to } = getMonthRangeByMonthYear(selectedMonth, selectedYear);
       const expenses = getExpensesInRangeByUserId(user.id, from, to);
 
       // Group expenses by categoryId
@@ -75,7 +78,7 @@ export function useCategoriesBreakdown(): {
         error: error instanceof Error ? error.message : 'Failed to load categories',
       };
     }
-  }, [user?.id, t, refreshKeys.expenses, refreshKeys.categories]);
+  }, [user?.id, t, selectedMonth, selectedYear, refreshKeys.expenses, refreshKeys.categories]);
 
   return result;
 }

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -9,7 +9,7 @@
 		"ios": "expo run:ios",
 		"web": "expo start --web",
 		"test": "jest --watchAll",
-		"check": "bunx biome check --write"
+		"check": "bunx biome check --write ."
 	},
 	"jest": {
 		"preset": "jest-expo"

--- a/mobile/utils/datetime.ts
+++ b/mobile/utils/datetime.ts
@@ -10,6 +10,16 @@ export const getMonthRange = (date: Date) => {
   };
 };
 
+export const getMonthRangeByMonthYear = (month: number, year: number) => {
+  const start = new Date(year, month, 1);
+  const end = new Date(year, month + 1, 0, 23, 59, 59, 999);
+
+  return {
+    from: start.toISOString(),
+    to: end.toISOString(),
+  };
+};
+
 export const formatDateWithLocale = (date: Date, locale: (typeof SUPPORTED_LANGUAGES)[number]) => {
   const localeMap = {
     en: 'en-US',


### PR DESCRIPTION
## Add month year selection to home page

<!-- A clear, concise title describing your change. -->
<!-- Delete sections or section content as needed -->

### Summary

With previous versions, it was not possible to go backwards in time to see past summaries of expenditures. This poses an issue since it would be good to essentially get a report of the past items and be able to see them as needed. This PR adds that functionality by adding a calendar button at the top right for users to select their desired month and year. 

### Related Issues

<!-- Link to any relevant issues or tickets (e.g., Closes #123, Fixes #456) -->

Fixes #205 

### Changes Made

- List key changes or features added
- Note any refactoring or bug fixes
- Mention removed or deprecated code

### How to Test

- Changed homepage components and child components to use a selected year and month 
- Added bottom sheets for date range selector for home page 

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have made corresponding changes to documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed

### Additional Context

Add any other relevant context, screenshots, or information for reviewers.

### Reviewer Notes

- Are there specific areas you want feedback on?
- Any known issues or potential risks?
- Is there a particular file or section to focus on?
