### PR TITLE
feat: added payment method based breakdown in home page

### DIFF
--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -2,7 +2,7 @@ import { useFocusEffect } from 'expo-router';
 import { useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ScrollView, View } from 'react-native';
-import { Divider, FAB, IconButton, Text, useTheme } from 'react-native-paper';
+import { FAB, IconButton, Text, useTheme } from 'react-native-paper';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import DateSelectorBottomSheet from '../../components/BottomSheets/DateSelectorBottomSheet';
 import EditExpenseBottomSheet from '../../components/BottomSheets/EditExpenseBottomSheet';
@@ -11,6 +11,7 @@ import ExpenseDetailBottomSheet from '../../components/BottomSheets/ExpenseDetai
 import ErrorBoundary from '../../components/ErrorBoundary';
 import { BudgetOverview } from '../../components/Home/BudgetOverview';
 import { CategoriesBreakdown } from '../../components/Home/CategoriesBreakdown';
+import { PaymentMethodsBreakdown } from '../../components/Home/PaymentMethodsBreakdown';
 import { RecentTransactions } from '../../components/Home/RecentTransactions';
 import type { Expense } from '../../db/schema';
 
@@ -165,7 +166,10 @@ export default function HomePage() {
               selectedMonth={selectedMonth}
               selectedYear={selectedYear}
             />
-            <Divider />
+            <PaymentMethodsBreakdown
+              selectedMonth={selectedMonth}
+              selectedYear={selectedYear}
+            />
             <RecentTransactions
               onPress={handleExpensePress}
               selectedMonth={selectedMonth}

--- a/mobile/assets/lang/en.json
+++ b/mobile/assets/lang/en.json
@@ -119,13 +119,17 @@
 		"cash": "Cash",
 		"bankTransfer": "Bank Transfer",
 		"digitalWallet": "Digital Wallet",
-		"other": "Other"
+		"other": "Other",
+		"setupPaymentMethods": "Set up payment methods in your profile to start tracking expenses.",
+		"noExpenses": "No expenses",
+		"spending": "Spending",
+		"countTransaction": "{{count}} transaction",
+		"countTransactions": "{{count}} transactions"
 	},
 	"home": {
 		"welcome": "Welcome",
 		"monthlyOverview": "Monthly Overview",
 		"recentTransactions": "Recent Transactions",
-		"currentMonth": "Current Month",
 		"topCategories": "Top Categories",
 		"totalBudget": "Total Budget",
 		"totalSpent": "Total Spent",
@@ -180,7 +184,7 @@
 		"descriptionOptional": "Description (optional)",
 		"amountCurrency": "Amount ({{currency}})",
 		"amount": {
-      "amount": "Amount",
+			"amount": "Amount",
 			"validNumber": "Please enter a valid amount",
 			"postiveOnly": "Amount cannot be negative",
 			"largerThanZero": "Amount must be greater than zero",
@@ -189,7 +193,7 @@
 			"valueTooLarge": "Budget is too large"
 		},
 		"budget": {
-      "budget": "budget", 
+			"budget": "budget",
 			"validNumber": "Please enter a valid budget",
 			"postiveOnly": "Budget cannot be negative",
 			"largerThanZero": "Budget must be greater than zero",

--- a/mobile/assets/lang/ja.json
+++ b/mobile/assets/lang/ja.json
@@ -119,13 +119,17 @@
 		"cash": "現金",
 		"bankTransfer": "銀行振込",
 		"digitalWallet": "デジタルウォレット",
-		"other": "その他"
+		"other": "その他",
+		"setupPaymentMethods": "プロフィールで支払い方法を設定して、支出の追跡を開始してください。",
+		"noExpenses": "支出なし",
+		"spending": "支出",
+		"countTransaction": "{{count}}取引",
+		"countTransactions": "{{count}}取引"
 	},
 	"home": {
 		"welcome": "ようこそ",
 		"monthlyOverview": "月間概要",
 		"recentTransactions": "最近の取引",
-		"currentMonth": "今月",
 		"topCategories": "主要カテゴリ",
 		"totalBudget": "総予算",
 		"totalSpent": "総支出",
@@ -180,7 +184,7 @@
 		"descriptionOptional": "説明（任意）",
 		"amountCurrency": "金額 ({{currency}})",
 		"amount": {
-      "amount": "金額",
+			"amount": "金額",
 			"validNumber": "有効な金額を入力してください",
 			"postiveOnly": "金額はマイナスにできません",
 			"largerThanZero": "金額はゼロより大きくなければなりません",
@@ -189,7 +193,7 @@
 			"valueTooLarge": "予算が大きすぎます"
 		},
 		"budget": {
-      "budget": "予算",
+			"budget": "予算",
 			"validNumber": "有効な予算を入力してください",
 			"postiveOnly": "予算はマイナスにできません",
 			"largerThanZero": "予算はゼロより大きくなければなりません",

--- a/mobile/components/Home/PaymentMethodsBreakdown.tsx
+++ b/mobile/components/Home/PaymentMethodsBreakdown.tsx
@@ -1,0 +1,70 @@
+import { useTranslation } from 'react-i18next';
+import { View } from 'react-native';
+import { Text, useTheme } from 'react-native-paper';
+import { usePaymentMethodsBreakdown } from '../../hooks/usePaymentMethodsBreakdown';
+import { PaymentMethodList } from '../PaymentMethodList';
+
+interface PaymentMethodsBreakdownProps {
+  selectedMonth: number;
+  selectedYear: number;
+}
+
+export const PaymentMethodsBreakdown = ({
+  selectedMonth,
+  selectedYear,
+}: PaymentMethodsBreakdownProps) => {
+  const theme = useTheme();
+  const { t } = useTranslation();
+  const { paymentMethods, loading, error } = usePaymentMethodsBreakdown(
+    selectedMonth,
+    selectedYear,
+  );
+
+  if (error) {
+    return (
+      <View>
+        <Text
+          variant="headlineMedium"
+          style={{
+            marginBottom: 24,
+            fontWeight: '700',
+            color: theme.colors.onBackground,
+          }}
+        >
+          {t('paymentMethods.title')}
+        </Text>
+        <Text
+          variant="bodyMedium"
+          style={{ color: theme.colors.error }}
+        >
+          {error}
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View>
+      <Text
+        variant="headlineMedium"
+        style={{
+          marginBottom: 24,
+          fontWeight: '700',
+          color: theme.colors.onBackground,
+        }}
+      >
+        {t('paymentMethods.title')}
+      </Text>
+      {loading ? (
+        <Text
+          variant="bodyMedium"
+          style={{ color: theme.colors.onSurfaceVariant }}
+        >
+          {t('status.loading')}
+        </Text>
+      ) : (
+        <PaymentMethodList paymentMethods={paymentMethods} />
+      )}
+    </View>
+  );
+};

--- a/mobile/components/PaymentMethodList.tsx
+++ b/mobile/components/PaymentMethodList.tsx
@@ -1,0 +1,63 @@
+import { useTranslation } from 'react-i18next';
+import { View } from 'react-native';
+import { Text, useTheme } from 'react-native-paper';
+import type { PaymentMethod } from '../db/schema';
+import type { PaymentMethodWithSpending } from '../db/types';
+import { PaymentMethodListItem } from './PaymentMethodListItem';
+
+interface Props {
+  paymentMethods: PaymentMethodWithSpending[] | PaymentMethod[];
+}
+
+export const PaymentMethodList = ({ paymentMethods }: Props) => {
+  const theme = useTheme();
+  const { t } = useTranslation();
+
+  if (paymentMethods.length === 0) {
+    return (
+      <View
+        style={{
+          padding: 48,
+          alignItems: 'center',
+          backgroundColor: theme.colors.surface,
+          borderRadius: 8,
+          borderWidth: 1,
+          borderColor: theme.colors.outline,
+        }}
+      >
+        <Text
+          variant="titleLarge"
+          style={{
+            textAlign: 'center',
+            marginBottom: 16,
+            fontWeight: '600',
+            color: theme.colors.onSurface,
+          }}
+        >
+          {t('paymentMethods.noPaymentMethods')}
+        </Text>
+        <Text
+          variant="bodyMedium"
+          style={{
+            textAlign: 'center',
+            color: theme.colors.onSurfaceVariant,
+            lineHeight: 24,
+          }}
+        >
+          {t('paymentMethods.setupPaymentMethods')}
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={{ paddingBottom: 16 }}>
+      {paymentMethods.map((paymentMethod) => (
+        <PaymentMethodListItem
+          key={paymentMethod.id}
+          paymentMethod={paymentMethod}
+        />
+      ))}
+    </View>
+  );
+};

--- a/mobile/components/PaymentMethodListItem.tsx
+++ b/mobile/components/PaymentMethodListItem.tsx
@@ -1,0 +1,94 @@
+import { useTranslation } from 'react-i18next';
+import { View } from 'react-native';
+import { Text, useTheme } from 'react-native-paper';
+import type { PaymentMethod } from '../db/schema';
+import type { PaymentMethodWithSpending } from '../db/types';
+import { formatAmount } from '../db/utils';
+import { useUser } from './contexts/UserContext';
+
+interface Props {
+  paymentMethod: PaymentMethodWithSpending | PaymentMethod;
+}
+
+function isPaymentMethodWithSpending(
+  pm: PaymentMethodWithSpending | PaymentMethod,
+): pm is PaymentMethodWithSpending {
+  return typeof (pm as PaymentMethodWithSpending).spent === 'number';
+}
+
+export const PaymentMethodListItem = ({ paymentMethod }: Props) => {
+  const theme = useTheme();
+  const { t } = useTranslation();
+  const { userSetting } = useUser();
+  const currency = userSetting?.currency ?? 'USD';
+
+  // Type guard for PaymentMethodWithSpending
+  const spent = isPaymentMethodWithSpending(paymentMethod) ? paymentMethod.spent : undefined;
+  const transactionCount = isPaymentMethodWithSpending(paymentMethod)
+    ? paymentMethod.transactionCount
+    : undefined;
+
+  // Derived values
+  const spentFormatted = spent !== undefined ? formatAmount(spent, currency) : null;
+  const transactionCountText =
+    transactionCount !== undefined
+      ? transactionCount === 1
+        ? t('paymentMethods.countTransaction', { count: transactionCount })
+        : t('paymentMethods.countTransactions', { count: transactionCount })
+      : null;
+
+  return (
+    <View
+      style={{
+        marginVertical: 4,
+        padding: 24,
+        backgroundColor: theme.colors.surface,
+        borderRadius: 8,
+        borderWidth: 1,
+        borderColor: theme.colors.outline,
+        shadowColor: '#000000',
+        shadowOffset: { width: 0, height: 1 },
+        shadowOpacity: 0.05,
+        shadowRadius: 2,
+        elevation: 1,
+      }}
+    >
+      <View style={{ gap: 20 }}>
+        <View
+          style={{
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+          }}
+        >
+          <Text
+            variant="titleMedium"
+            style={{ fontWeight: '600', color: theme.colors.onSurface }}
+          >
+            {paymentMethod.name}
+          </Text>
+          <Text
+            variant="bodyMedium"
+            style={{
+              fontWeight: '600',
+              color: theme.colors.onSurface,
+            }}
+          >
+            {spentFormatted || t('paymentMethods.noExpenses')}
+            {spent !== undefined && transactionCount !== undefined && spent > 0 && (
+              <Text
+                variant="bodySmall"
+                style={{
+                  color: theme.colors.onSurfaceVariant,
+                  fontWeight: '500',
+                }}
+              >
+                {` (${transactionCountText})`}
+              </Text>
+            )}
+          </Text>
+        </View>
+      </View>
+    </View>
+  );
+};

--- a/mobile/db/types.ts
+++ b/mobile/db/types.ts
@@ -5,6 +5,11 @@ export interface CategoryWithSpending extends Category {
   percentage: number;
 }
 
+export interface PaymentMethodWithSpending extends PaymentMethod {
+  spent: number;
+  transactionCount: number;
+}
+
 export interface ExpenseFull extends Expense {
   category: Pick<Category, 'id' | 'name'> | null;
   paymentMethod: Pick<PaymentMethod, 'id' | 'name'> | null;

--- a/mobile/hooks/usePaymentMethodsBreakdown.ts
+++ b/mobile/hooks/usePaymentMethodsBreakdown.ts
@@ -1,0 +1,97 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useRefreshKey } from '../components/contexts/RefreshKeyContext';
+import { useUser } from '../components/contexts/UserContext';
+import { getExpensesInRangeByUserId } from '../db/repository/expense';
+import { getPaymentMethodsByUserId } from '../db/repository/paymentMethod';
+import type { PaymentMethodWithSpending } from '../db/types';
+import { getMonthRangeByMonthYear } from '../utils/datetime';
+
+export function usePaymentMethodsBreakdown(
+  selectedMonth: number,
+  selectedYear: number,
+): {
+  paymentMethods: PaymentMethodWithSpending[];
+  loading: boolean;
+  error: string | null;
+} {
+  const { t } = useTranslation();
+  const { user } = useUser();
+  const { refreshKeys } = useRefreshKey();
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: refreshKeys are intentionally used to trigger re-fetching
+  const result = useMemo(() => {
+    if (!user?.id) {
+      return { paymentMethods: [], loading: false, error: null };
+    }
+
+    try {
+      // Fetch payment methods (excluding deleted)
+      const paymentMethods = getPaymentMethodsByUserId(user.id);
+
+      // Fetch selected month's expenses (excluding deleted)
+      const { from, to } = getMonthRangeByMonthYear(selectedMonth, selectedYear);
+      const expenses = getExpensesInRangeByUserId(user.id, from, to);
+
+      // Group expenses by paymentMethodId
+      const paymentMethodTotals: Record<string, { spent: number; count: number }> = {};
+      let uncategorizedTotal = 0;
+      let uncategorizedCount = 0;
+
+      expenses.forEach((exp) => {
+        if (exp.paymentMethodId) {
+          if (!paymentMethodTotals[exp.paymentMethodId]) {
+            paymentMethodTotals[exp.paymentMethodId] = { spent: 0, count: 0 };
+          }
+          paymentMethodTotals[exp.paymentMethodId].spent += exp.amount;
+          paymentMethodTotals[exp.paymentMethodId].count += 1;
+        } else {
+          uncategorizedTotal += exp.amount;
+          uncategorizedCount += 1;
+        }
+      });
+
+      // Shape the data
+      const result: PaymentMethodWithSpending[] = paymentMethods.map((pm) => {
+        const data = paymentMethodTotals[pm.id] || { spent: 0, count: 0 };
+        return {
+          id: pm.id,
+          userId: pm.userId,
+          name: pm.name,
+          type: pm.type,
+          deletedAt: pm.deletedAt,
+          createdAt: pm.createdAt,
+          updatedAt: pm.updatedAt,
+          spent: data.spent,
+          transactionCount: data.count,
+        } as PaymentMethodWithSpending;
+      });
+
+      // Add "No Payment Method" if needed
+      if (uncategorizedTotal > 0) {
+        result.push({
+          id: 'no-payment-method',
+          userId: user.id,
+          name: t('paymentMethods.noPaymentMethod'),
+          type: 'other',
+          deletedAt: null,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          spent: uncategorizedTotal,
+          transactionCount: uncategorizedCount,
+        } as PaymentMethodWithSpending);
+      }
+
+      return { paymentMethods: result, loading: false, error: null };
+    } catch (error) {
+      console.error('Error fetching payment methods breakdown data:', error);
+      return {
+        paymentMethods: [],
+        loading: false,
+        error: error instanceof Error ? error.message : 'Failed to load payment methods',
+      };
+    }
+  }, [user?.id, t, selectedMonth, selectedYear, refreshKeys.expenses, refreshKeys.paymentMethods]);
+
+  return result;
+}


### PR DESCRIPTION
## Add payment method based breakdown in home page

<!-- A clear, concise title describing your change. -->
<!-- Delete sections or section content as needed -->

### Summary

There was a request from SO to add an additional section to aggregate expenses based on payment method in the home page. 

### Related Issues

<!-- Link to any relevant issues or tickets (e.g., Closes #123, Fixes #456) -->

Fixes #190 

### Changes Made

- Added new components necessary for payment method based breakdown 
- Added new hook for calculating based off of payment method using date range 
- Removed weird divider component being added to create separation from past prs 
- Added and cleaned up translations

### How to Test

- Steps to reproduce or verify the changes
- Any test commands or setup required
- Include screenshots or recordings if helpful

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have made corresponding changes to documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed

### Additional Context

Add any other relevant context, screenshots, or information for reviewers.

### Reviewer Notes

- Are there specific areas you want feedback on?
- Any known issues or potential risks?
- Is there a particular file or section to focus on?
