### PR TITLE
feat: added lint and format commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ include makefiles/init.mk
 # include makefiles/generator.mk
 include makefiles/runner.mk
 include makefiles/eas.mk
+include makefiles/utility.mk
 
 MAKEFLAGS += --no-print-directory
 

--- a/makefiles/utility.mk
+++ b/makefiles/utility.mk
@@ -1,0 +1,10 @@
+##@ Utility - QoL scripts to interact with the code base
+
+.PHONY: lint
+lint: ## Lints the entire codebase
+	@cd ./mobile && bun run lint
+
+.PHONY: format
+format: ## format the entire codebase
+	@cd ./mobile && bun run format
+

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -9,7 +9,9 @@
 		"ios": "expo run:ios",
 		"web": "expo start --web",
 		"test": "jest --watchAll",
-		"check": "bunx biome check --write ."
+		"check": "bunx biome check --write .",
+    "lint": "bunx biome lint .",
+    "format": "bunx biome format --write ."
 	},
 	"jest": {
 		"preset": "jest-expo"


### PR DESCRIPTION
## Added lint and format commands to makefile

<!-- A clear, concise title describing your change. -->
<!-- Delete sections or section content as needed -->

### Summary

Got annoying to cd into mobile directory and run bun run commands in nvim. Instead added the necessary commands in to the makefile so whenever a new terminal is spun up, i can call it directly. 

### Related Issues

<!-- Link to any relevant issues or tickets (e.g., Closes #123, Fixes #456) -->

### Changes Made

- Added utility.mk that contains the lint and format commands 
- Added lint and format commands in bun package.json 

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, especially in hard-to-understand areas
- [x] I have made corresponding changes to documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed

