### PR TITLE
fix: resolve Radix UI and Framer Motion type conflict in dialog

### DIFF
--- a/client/src/components/ui/dialog.tsx
+++ b/client/src/components/ui/dialog.tsx
@@ -27,7 +27,6 @@ const DialogPortal = DialogPrimitive.Portal;
 
 function DialogOverlay({
 	className,
-	...props
 }: ComponentProps<typeof DialogPrimitive.Overlay>) {
 	return (
 		<DialogPrimitive.Overlay forceMount asChild>
@@ -40,7 +39,6 @@ function DialogOverlay({
 				initial="initial"
 				animate="animate"
 				exit="exit"
-				{...props}
 			/>
 		</DialogPrimitive.Overlay>
 	);
@@ -49,6 +47,10 @@ function DialogOverlay({
 function DialogContent({
 	className,
 	children,
+	onDrag: _onDrag,
+	onDragEnd: _onDragEnd,
+	onDragStart: _onDragStart,
+	onAnimationStart: _onAnimationStart,
 	...props
 }: ComponentProps<typeof DialogPrimitive.Content>) {
 	const open = useContext(DialogOpenContext);


### PR DESCRIPTION
## Summary
- Fixes TypeScript build failure caused by incompatible `onDrag`, `onDragEnd`, `onDragStart`, and `onAnimationStart` event handler types between Radix UI and Framer Motion
- Destructures conflicting props out of the spread in `DialogContent` and removes unused prop spread in `DialogOverlay`

## Test plan
- [ ] Verify `bun run build` passes without type errors
- [ ] Verify dialog open/close animations still work on mobile and desktop