### PR TITLE
fix: resolve Recharts Tooltip formatter type errors

### DIFF
--- a/client/src/components/Report/MemberContributionChart.tsx
+++ b/client/src/components/Report/MemberContributionChart.tsx
@@ -98,7 +98,7 @@ export const MemberContributionChart = ({
 					axisLine={false}
 					width={50}
 				/>
-				<Tooltip formatter={(value: number) => formatValue(value)} />
+				<Tooltip formatter={(value) => formatValue(Number(value))} />
 				<Legend wrapperStyle={{ fontSize: 12 }} />
 
 				{data.map((member, i) => (

--- a/client/src/components/Report/SpendTrendChart.tsx
+++ b/client/src/components/Report/SpendTrendChart.tsx
@@ -129,7 +129,7 @@ export const SpendTrendChart = ({ data, currency, month, year }: Props) => {
 					axisLine={false}
 					width={50}
 				/>
-				<Tooltip formatter={(value: number) => formatValue(value)} />
+				<Tooltip formatter={(value) => formatValue(Number(value))} />
 				<Legend wrapperStyle={{ fontSize: 12 }} />
 
 				{/* Current year actual spend */}


### PR DESCRIPTION
## Summary
- Fix TypeScript build errors in `MemberContributionChart` and `SpendTrendChart` caused by Recharts `Tooltip` formatter expecting `value: number | undefined` rather than `value: number`
- Drop explicit type annotation and wrap with `Number()` to satisfy the `Formatter` signature

## Test plan
- [ ] Verify `bun run build` (tsc -b && vite build) succeeds
- [ ] Verify chart tooltips still display formatted currency values